### PR TITLE
Update shimmer source for KnickKnackLabs org transfer

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1,6 +1,6 @@
 {
   "frames": "KnickKnackLabs/frames",
-  "shimmer": "ricon-family/shimmer",
+  "shimmer": "KnickKnackLabs/shimmer",
   "wallpapers": "KnickKnackLabs/wallpapers",
   "monkeys": "KnickKnackLabs/monkeys",
   "recorder": "KnickKnackLabs/recorder"


### PR DESCRIPTION
## Summary

- Update shimmer source in `sources.json` from `ricon-family/shimmer` to `KnickKnackLabs/shimmer`
- The shimmer repository is being transferred from the `ricon-family` org to the `KnickKnackLabs` org, and this updates shiv's source reference to reflect the new location

🤖 Generated with [Claude Code](https://claude.com/claude-code)