### PR TITLE
Fix --help for shiv-managed tools

### DIFF
--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -14,9 +14,3 @@ case ":$PATH:" in
   *":$SHIV_BIN_DIR:"*) ;;
   *) echo "export PATH=\"$SHIV_BIN_DIR:\$PATH\"" ;;
 esac
-
-# Output aliases for all registered tools
-shiv_init_registry
-jq -r 'to_entries[] | "\(.key) \(.value)"' "$SHIV_REGISTRY" | while read -r name repo; do
-  shiv_shell_config "$name" "$repo"
-done

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -60,8 +60,3 @@ shiv_unregister() {
   tmp=$(jq --arg n "$name" 'del(.[$n])' "$SHIV_REGISTRY")
   echo "$tmp" > "$SHIV_REGISTRY"
 }
-
-# Output shell config for a tool (no-op: shims in ~/.local/bin handle everything)
-shiv_shell_config() {
-  :
-}


### PR DESCRIPTION
## Summary

- Shims now intercept `--help`/`-h`/`help` and show the repo's available tasks (`mise tasks`) instead of passing through to `mise run` (which showed mise's own generic run help)
- Removed alias generation from `shiv_shell_config()` — shims in `~/.local/bin` handle everything, aliases were bypassing them and defeating the help fix

**Before:** `shiv --help` showed mise's run help (confusing)
**After:** `shiv --help` shows shiv's actual tasks (useful)

This fix applies to all shiv-managed tools. Run `shiv update` after merging to regenerate existing shims.

## Test plan

- [x] `shiv --help` shows shiv tasks
- [x] `shiv help` shows shiv tasks
- [x] `shimmer --help` shows shimmer tasks
- [x] `shiv update` regenerates all shims with new template
- [x] `shiv shell` no longer outputs aliases (just PATH setup)
- [x] Normal task execution (`shiv list`, `shimmer welcome`, etc.) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)