### PR TITLE
Export CALLER_PWD in shim template

### DIFF
--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -31,6 +31,7 @@ if [ ! -d "\$REPO" ]; then
   echo "$name: run 'shiv doctor' to diagnose" >&2
   exit 1
 fi
+export CALLER_PWD="\$PWD"
 case "\${1:-}" in
   --help|-h|help)
     exec mise -C "\$REPO" tasks


### PR DESCRIPTION
## Summary
- Shims created by shiv now `export CALLER_PWD="$PWD"` before exec'ing mise
- Tools like `shimmer as` need the caller's working directory to find context-dependent resources (e.g. `agents/` directory)
- Uses the generic `CALLER_PWD` convention — any shiv-managed tool can read it

## Context
Companion to KnickKnackLabs/shimmer#617 which renames `SHIMMER_CALLER_PWD` → `CALLER_PWD` on the shimmer side.

Fixes the broken `shimmer as` command when invoked via the shiv shim.

## Test plan
- [ ] Run `shiv install shimmer` to regenerate the shim
- [ ] Verify `~/.local/bin/shimmer` contains `export CALLER_PWD="$PWD"`
- [ ] From `~/fold`, run `eval $(shimmer as)` — should find `agents/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)