### PR TITLE
feat: add `shiv which` subcommand

### DIFF
--- a/.mise/tasks/which
+++ b/.mise/tasks/which
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#MISE description="Print the install path of a managed tool"
+#USAGE arg "<name>" help="Command name to look up"
+set -eo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$REPO_DIR/lib/shim.sh"
+
+NAME="${usage_name}"
+
+shiv_init_registry
+
+PATH_VAL=$(jq -r --arg n "$NAME" '.[$n] // empty' "$SHIV_REGISTRY")
+
+if [ -z "$PATH_VAL" ]; then
+  echo "shiv: '$NAME' is not a managed tool" >&2
+  echo "Run 'shiv list' to see managed tools." >&2
+  exit 1
+fi
+
+echo "$PATH_VAL"


### PR DESCRIPTION
## Summary
- Adds `shiv which <name>` — prints the install path of a managed tool
- Enables scriptable navigation: `cd $(shiv which den)`
- Looks up the tool in the shiv registry, exits 1 with a helpful message if not found

Partial fix for #12 (the `shiv ls` improvements are a separate effort).

## Test plan
- [x] `shiv which den` → prints correct path
- [x] `shiv which shiv` → prints shiv's own path
- [x] `shiv which nonexistent` → stderr error, exit 1
- [x] `cd $(shiv which den)` → lands in the right directory
- [x] Shows up in `shiv --help`

🌀 Magic applied with Wibey CLI 🪄 (https://wibey.walmart.com/cli)