### PR TITLE
WIP: Support custom command name on install (--as)

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 #MISE description="Install a tool — from the package index or a local path"
-#USAGE arg "<name>" help="Command name (e.g., shimmer, frames) or name and path"
+#USAGE arg "<name>" help="Package name (e.g., shimmer, frames)"
 #USAGE arg "[path]" help="Local path to repo (optional — if omitted, clones from package index)"
+#USAGE flag "--as <command>" help="Custom command name (default: same as package name)"
 set -eo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$REPO_DIR/lib/shim.sh"
 
-NAME="${usage_name}"
+PACKAGE="${usage_name}"
+COMMAND="${usage_as:-$PACKAGE}"
 LOCAL_PATH="${usage_path:-}"
 
 if [ -n "$LOCAL_PATH" ]; then
@@ -15,9 +17,9 @@ if [ -n "$LOCAL_PATH" ]; then
   TOOL_PATH="$(cd "$LOCAL_PATH" && pwd)"
 else
   # Package install — look up in sources and clone
-  GH_REPO=$(shiv_lookup "$NAME")
+  GH_REPO=$(shiv_lookup "$PACKAGE")
   if [ -z "$GH_REPO" ]; then
-    echo "Error: '$NAME' not found in package index" >&2
+    echo "Error: '$PACKAGE' not found in package index" >&2
     echo ""
     echo "Available packages:"
     shiv_list_sources | while read -r pkg repo; do
@@ -26,7 +28,7 @@ else
     exit 1
   fi
 
-  TOOL_PATH="$SHIV_PACKAGES_DIR/$NAME"
+  TOOL_PATH="$SHIV_PACKAGES_DIR/$PACKAGE"
 
   if [ -d "$TOOL_PATH" ]; then
     echo "Already cloned: $TOOL_PATH"
@@ -47,13 +49,16 @@ if [ ! -f "$TOOL_PATH/mise.toml" ]; then
   echo "Warning: no mise.toml found at $TOOL_PATH"
 fi
 
-shiv_create_shim "$NAME" "$TOOL_PATH"
-shiv_register "$NAME" "$TOOL_PATH"
-shiv_cache_tasks "$NAME" "$TOOL_PATH"
+shiv_create_shim "$COMMAND" "$TOOL_PATH"
+shiv_register "$COMMAND" "$TOOL_PATH"
+shiv_cache_tasks "$COMMAND" "$TOOL_PATH"
 
 echo ""
-echo "✓ Installed: $NAME → $TOOL_PATH"
-echo "  Shim: $SHIV_BIN_DIR/$NAME"
+echo "✓ Installed: $COMMAND → $TOOL_PATH"
+echo "  Shim: $SHIV_BIN_DIR/$COMMAND"
+if [ "$COMMAND" != "$PACKAGE" ]; then
+  echo "  Alias: $PACKAGE → $COMMAND"
+fi
 echo ""
 echo "Reload your shell or run:"
 echo "  eval \"\$(mise -C $REPO_DIR run -q shell)\""

--- a/.mise/tasks/test/_default
+++ b/.mise/tasks/test/_default
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 #MISE description="Run all tests"
-#MISE depends=["test:completions"]
+#MISE depends=["test:completions", "test:install"]

--- a/.mise/tasks/test/install
+++ b/.mise/tasks/test/install
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run install tests (BATS)"
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+bats "$REPO_DIR/test/install.bats"

--- a/test/install.bats
+++ b/test/install.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# shiv install test suite
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+
+setup() {
+  source "$REPO_DIR/lib/shim.sh"
+
+  # Use a temporary home for isolation
+  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  mkdir -p "$TEST_HOME"
+
+  # Override shiv paths to use test home
+  export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
+  export SHIV_DATA_DIR="$TEST_HOME/.local/share/shiv"
+  export SHIV_PACKAGES_DIR="$SHIV_DATA_DIR/packages"
+  export SHIV_CONFIG_DIR="$TEST_HOME/.config/shiv"
+  export SHIV_CACHE_DIR="$TEST_HOME/.cache/shiv"
+  export SHIV_REGISTRY="$SHIV_CONFIG_DIR/registry.json"
+  export SHIV_SOURCES_DIR="$SHIV_CONFIG_DIR/sources"
+
+  shiv_init_registry
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# ============================================================================
+# Basic install (local path)
+# ============================================================================
+
+@test "install: local path creates shim with package name" {
+  run mise -C "$REPO_DIR" run -q install shiv "$REPO_DIR"
+  [ "$status" -eq 0 ]
+  [ -f "$SHIV_BIN_DIR/shiv" ]
+  # Registry should have the entry
+  jq -e '.shiv' "$SHIV_REGISTRY"
+}
+
+# ============================================================================
+# Custom command name (--as)
+# ============================================================================
+
+@test "install --as: creates shim with custom name" {
+  run mise -C "$REPO_DIR" run -q install shiv "$REPO_DIR" --as sv
+  [ "$status" -eq 0 ]
+  [ -f "$SHIV_BIN_DIR/sv" ]
+  # Should NOT create a shim with the package name
+  [ ! -f "$SHIV_BIN_DIR/shiv" ]
+}
+
+@test "install --as: registers under custom name" {
+  mise -C "$REPO_DIR" run -q install shiv "$REPO_DIR" --as sv
+  # Registry key should be the custom name
+  jq -e '.sv' "$SHIV_REGISTRY"
+  # Package name should not be in registry
+  run jq -e '.shiv' "$SHIV_REGISTRY"
+  [ "$status" -ne 0 ]
+}
+
+@test "install --as: caches under custom name" {
+  mise -C "$REPO_DIR" run -q install shiv "$REPO_DIR" --as sv
+  [ -f "$SHIV_CACHE_DIR/completions/sv.cache" ]
+  [ ! -f "$SHIV_CACHE_DIR/completions/shiv.cache" ]
+}
+
+@test "install --as: shim points to correct repo" {
+  mise -C "$REPO_DIR" run -q install shiv "$REPO_DIR" --as sv
+  # Shim should contain the repo path (resolved to absolute)
+  grep -q "# managed by shiv" "$SHIV_BIN_DIR/sv"
+  grep -q "REPO=" "$SHIV_BIN_DIR/sv"
+}
+
+@test "install --as: output shows alias" {
+  run mise -C "$REPO_DIR" run -q install shiv "$REPO_DIR" --as sv
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Alias: shiv → sv"
+}
+
+@test "install --as: completions use custom name" {
+  mise -C "$REPO_DIR" run -q install shiv "$REPO_DIR" --as sv
+  run mise -C "$REPO_DIR" run -q completions:bash
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "complete -F _shiv_complete_sv sv"
+}
+
+# ============================================================================
+# Default behavior (no --as)
+# ============================================================================
+
+@test "install: without --as uses package name as command" {
+  run mise -C "$REPO_DIR" run -q install shiv "$REPO_DIR"
+  [ "$status" -eq 0 ]
+  [ -f "$SHIV_BIN_DIR/shiv" ]
+  jq -e '.shiv' "$SHIV_REGISTRY"
+  # No alias line in output
+  echo "$output" | grep -qv "Alias:" || true
+}


### PR DESCRIPTION
## Summary

Adds `--as` flag to `shiv install`:

```bash
shiv install wallpapers --as wp
```

Package name drives clone/lookup, command name drives shim/registry/cache.

## Status: Draft — needs discussion

The basic mechanism works and has tests, but the design has open questions around edge cases (#27):
- Double install (same package, different command names)
- Uninstall/update by package name when registered under an alias
- Whether an alias registry or enriched registry format would be better
- Multiple aliases per package

Parking this as a draft until we align on the approach.

## Closes

- #19 (once finalized)

## Related

- #27 — Edge cases for custom command names

🤖 Generated with [Claude Code](https://claude.com/claude-code)