### PR TITLE
Use chicle.knacklabs.co vanity URL

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -33,7 +33,7 @@ SHIV_BIN_DIR="${SHIV_BIN_DIR:-$HOME/.local/bin}"
 SHIV_CONFIG_DIR="${SHIV_CONFIG_DIR:-$HOME/.config/shiv}"
 SHIV_REGISTRIES="${SHIV_REGISTRIES:-}"
 
-CHICLE_URL="https://raw.githubusercontent.com/KnickKnackLabs/chicle/74cb095/chicle.sh"
+CHICLE_URL="https://chicle.knacklabs.co/chicle.sh"
 TOTAL_STEPS=6
 
 # Ensure TERM is set (tput needs it; containers often have TERM=dumb or unset)


### PR DESCRIPTION
## Summary

- Replaces the pinned `raw.githubusercontent.com` chicle URL with the new `chicle.knacklabs.co` vanity URL
- The vanity URL always serves the latest chicle release (currently v0.2.0), deployed automatically by chicle's release CI

## Test plan

- [ ] Run `bash docs/install.sh` and verify chicle loads correctly
- [ ] Verify chicle TUI functions work in the installer (confirm prompts, styled output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)