### PR TITLE
Add pipx to mise.toml dependencies

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 bats = "1.13.0"
+pipx = "1.8.0"
 "pipx:check-jsonschema" = "0.36.0"


### PR DESCRIPTION
## Summary

- Adds `pipx` as an explicit dependency in `mise.toml`
- mise needs pipx to install `pipx:check-jsonschema`, which was failing on minimal environments (Alpine Docker) where pipx isn't pre-installed

## Test plan

- [ ] Verify test-install CI passes on Alpine Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)