### PR TITLE
Respect XDG variables in install script

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -28,9 +28,9 @@ set -eo pipefail
 
 # Configuration via environment variables
 SHIV_NONINTERACTIVE="${SHIV_NONINTERACTIVE:-0}"
-SHIV_INSTALL_PATH="${SHIV_INSTALL_PATH:-$HOME/.local/share/shiv/packages/shiv}"
+SHIV_INSTALL_PATH="${SHIV_INSTALL_PATH:-${XDG_DATA_HOME:-$HOME/.local/share}/shiv/packages/shiv}"
 SHIV_BIN_DIR="${SHIV_BIN_DIR:-$HOME/.local/bin}"
-SHIV_CONFIG_DIR="${SHIV_CONFIG_DIR:-$HOME/.config/shiv}"
+SHIV_CONFIG_DIR="${SHIV_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/shiv}"
 SHIV_REGISTRIES="${SHIV_REGISTRIES:-}"
 
 CHICLE_URL="https://chicle.knacklabs.co/chicle.sh"


### PR DESCRIPTION
## Summary

- `SHIV_INSTALL_PATH` now respects `XDG_DATA_HOME` (falls back to `$HOME/.local/share`)
- `SHIV_CONFIG_DIR` now respects `XDG_CONFIG_HOME` (falls back to `$HOME/.config`)
- `SHIV_BIN_DIR` left as `$HOME/.local/bin` — no XDG standard for bin dirs

The lib files (`registry.sh`, `cache.sh`, `shim.sh`) already had proper XDG fallbacks. This was the only remaining gap — the install script.

Closes #23

## Audit

| Path | Variable | XDG-aware? |
|------|----------|------------|
| `lib/registry.sh` | `SHIV_CONFIG_DIR` | Already |
| `lib/cache.sh` | `SHIV_CACHE_DIR` | Already |
| `lib/shim.sh` | `SHIV_DATA_DIR` | Already |
| `lib/shim.sh` | `SHIV_BIN_DIR` | N/A (no XDG standard) |
| `docs/install.sh` | `SHIV_INSTALL_PATH` | **Fixed** |
| `docs/install.sh` | `SHIV_CONFIG_DIR` | **Fixed** |
| `.github/workflows/*` | hardcoded defaults | Intentional (testing defaults) |

## Test plan

- [x] Verified only `docs/install.sh` had missing XDG support
- [x] CI workflow paths intentionally test defaults — left unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)