### PR TITLE
Replace check-jsonschema with sourcemeta/jsonschema

### DIFF
--- a/.mise/tasks/doctor
+++ b/.mise/tasks/doctor
@@ -8,14 +8,14 @@ source "$REPO_DIR/lib/shim.sh"
 shiv_init_registry
 
 # Validate registry schema
-if command -v check-jsonschema &>/dev/null; then
-  if check-jsonschema --schemafile "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY" 2>/dev/null; then
+if command -v jsonschema &>/dev/null; then
+  if jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY" 2>/dev/null; then
     echo "✓ Registry schema valid"
   else
     echo "✗ Registry schema invalid — run 'shiv registry:validate' for details"
   fi
 else
-  echo "- Registry schema check skipped (check-jsonschema not found)"
+  echo "- Registry schema check skipped (jsonschema not found)"
 fi
 echo ""
 

--- a/.mise/tasks/registry/validate
+++ b/.mise/tasks/registry/validate
@@ -7,11 +7,11 @@ source "$REPO_DIR/lib/registry.sh"
 
 shiv_init_registry
 
-if ! command -v check-jsonschema &>/dev/null; then
-  echo "Error: check-jsonschema not found" >&2
-  echo "Install with: pipx install check-jsonschema" >&2
+if ! command -v jsonschema &>/dev/null; then
+  echo "Error: jsonschema not found" >&2
+  echo "Install with: mise install jsonschema" >&2
   exit 1
 fi
 
-check-jsonschema --schemafile "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
 echo "✓ Registry is valid"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,3 @@
 [tools]
 bats = "1.13.0"
-python = "3.13"
-pipx = "1.8.0"
-"pipx:check-jsonschema" = "0.36.0"
+jsonschema = "14.14.2"

--- a/test/registry.bats
+++ b/test/registry.bats
@@ -209,24 +209,24 @@ teardown() {
 # ============================================================================
 
 @test "schema: empty registry is valid" {
-  if ! command -v check-jsonschema &>/dev/null; then
-    skip "check-jsonschema not found"
+  if ! command -v jsonschema &>/dev/null; then
+    skip "jsonschema not found"
   fi
-  check-jsonschema --schemafile "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
 }
 
 @test "schema: registry with package and aliases is valid" {
-  if ! command -v check-jsonschema &>/dev/null; then
-    skip "check-jsonschema not found"
+  if ! command -v jsonschema &>/dev/null; then
+    skip "jsonschema not found"
   fi
   shiv_register "foo" "/path/to/foo" "f"
-  check-jsonschema --schemafile "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
 }
 
 @test "schema: registry without aliases is valid" {
-  if ! command -v check-jsonschema &>/dev/null; then
-    skip "check-jsonschema not found"
+  if ! command -v jsonschema &>/dev/null; then
+    skip "jsonschema not found"
   fi
   shiv_register "foo" "/path/to/foo"
-  check-jsonschema --schemafile "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
 }


### PR DESCRIPTION
## Summary

- Replace `python + pipx + check-jsonschema` with `sourcemeta/jsonschema` — a single prebuilt binary with releases for darwin, linux, and windows
- Fixes CI failures on Alpine/Debian Docker (no C compiler for Python) and Windows (aqua doesn't package pipx)
- Updated: `mise.toml`, `doctor`, `registry:validate`, `test/registry.bats`

## Why

`check-jsonschema` is a Python tool installed via pipx. This dependency chain broke on:
- **Windows**: aqua doesn't support pipx on Windows
- **Alpine/Debian Docker**: minimal images lack a C compiler to build Python from source

`sourcemeta/jsonschema` is a standalone Rust binary distributed as prebuilt archives for all three platforms. No build toolchain needed.

## Test plan

- [x] `shiv doctor` — validates registry schema
- [x] `shiv registry:validate` — validates registry schema
- [x] `mise run test:registry` — all 27 tests pass, schema tests no longer skip
- [x] Validated against known-bad JSON — rejects with clear error (exit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)