### PR TITLE
fix: replace mapfile with while-read for bash 3.2 compatibility

### DIFF
--- a/.mise/tasks/doctor
+++ b/.mise/tasks/doctor
@@ -83,7 +83,10 @@ else
     fi
 
     # Check alias symlinks
-    mapfile -t aliases < <(shiv_registry_aliases "$name")
+    aliases=()
+    while IFS= read -r _alias; do
+      [ -n "$_alias" ] && aliases+=("$_alias")
+    done < <(shiv_registry_aliases "$name")
     for alias in "${aliases[@]}"; do
       if [ ! -L "$SHIV_BIN_DIR/$alias" ]; then
         issues+="    ✗ alias symlink missing: $SHIV_BIN_DIR/$alias"$'\n'

--- a/.mise/tasks/uninstall
+++ b/.mise/tasks/uninstall
@@ -48,7 +48,10 @@ fi
 
 # Gather metadata for summary card
 TOOL_PATH=$(shiv_registry_path "$NAME")
-mapfile -t ALIASES < <(shiv_registry_aliases "$NAME")
+ALIASES=()
+while IFS= read -r _alias; do
+  [ -n "$_alias" ] && ALIASES+=("$_alias")
+done < <(shiv_registry_aliases "$NAME")
 
 # Annotate PATH and SHIM with "(not found)" if missing
 path_display="${TOOL_PATH:--}"

--- a/.mise/tasks/update
+++ b/.mise/tasks/update
@@ -104,7 +104,10 @@ update_one() {
   shiv_cache_tasks "$name" "$repo"
 
   # Recreate alias symlinks
-  mapfile -t aliases < <(shiv_registry_aliases "$name")
+  aliases=()
+  while IFS= read -r _alias; do
+    [ -n "$_alias" ] && aliases+=("$_alias")
+  done < <(shiv_registry_aliases "$name")
   if [ ${#aliases[@]} -gt 0 ]; then
     shiv_create_alias_symlinks "$name" "${aliases[@]}"
   fi

--- a/test/list.bats
+++ b/test/list.bats
@@ -163,7 +163,10 @@ extract_packages() {
   run run_list
   [ "$status" -eq 0 ]
 
-  mapfile -t packages < <(echo "$output" | extract_packages)
+  packages=()
+  while IFS= read -r _pkg; do
+    [ -n "$_pkg" ] && packages+=("$_pkg")
+  done < <(echo "$output" | extract_packages)
   [ "${packages[0]}" = "alpha" ]
   [ "${packages[1]}" = "bravo" ]
   [ "${packages[2]}" = "charlie" ]
@@ -180,7 +183,10 @@ extract_packages() {
   run run_list --sort name --desc
   [ "$status" -eq 0 ]
 
-  mapfile -t packages < <(echo "$output" | extract_packages)
+  packages=()
+  while IFS= read -r _pkg; do
+    [ -n "$_pkg" ] && packages+=("$_pkg")
+  done < <(echo "$output" | extract_packages)
   [ "${packages[0]}" = "charlie" ]
   [ "${packages[1]}" = "bravo" ]
   [ "${packages[2]}" = "alpha" ]
@@ -201,7 +207,10 @@ extract_packages() {
   run run_list --sort updated
   [ "$status" -eq 0 ]
 
-  mapfile -t packages < <(echo "$output" | extract_packages)
+  packages=()
+  while IFS= read -r _pkg; do
+    [ -n "$_pkg" ] && packages+=("$_pkg")
+  done < <(echo "$output" | extract_packages)
   [ "${packages[0]}" = "new" ]
   [ "${packages[1]}" = "mid" ]
   [ "${packages[2]}" = "old" ]
@@ -218,7 +227,10 @@ extract_packages() {
   run run_list --sort updated --asc
   [ "$status" -eq 0 ]
 
-  mapfile -t packages < <(echo "$output" | extract_packages)
+  packages=()
+  while IFS= read -r _pkg; do
+    [ -n "$_pkg" ] && packages+=("$_pkg")
+  done < <(echo "$output" | extract_packages)
   [ "${packages[0]}" = "old" ]
   [ "${packages[1]}" = "mid" ]
   [ "${packages[2]}" = "new" ]

--- a/test/registry.bats
+++ b/test/registry.bats
@@ -71,7 +71,10 @@ teardown() {
 
 @test "registry: shiv_registry_aliases returns aliases" {
   shiv_register "foo" "/path/to/foo" "f" "fo"
-  mapfile -t aliases < <(shiv_registry_aliases "foo")
+  aliases=()
+  while IFS= read -r _alias; do
+    [ -n "$_alias" ] && aliases+=("$_alias")
+  done < <(shiv_registry_aliases "foo")
   [ "${#aliases[@]}" -eq 2 ]
   [ "${aliases[0]}" = "f" ]
   [ "${aliases[1]}" = "fo" ]
@@ -106,7 +109,10 @@ teardown() {
 @test "registry: shiv_registry_set_aliases updates aliases" {
   shiv_register "foo" "/path/to/foo" "f"
   shiv_registry_set_aliases "foo" "f" "fo" "x"
-  mapfile -t aliases < <(shiv_registry_aliases "foo")
+  aliases=()
+  while IFS= read -r _alias; do
+    [ -n "$_alias" ] && aliases+=("$_alias")
+  done < <(shiv_registry_aliases "foo")
   [ "${#aliases[@]}" -eq 3 ]
 }
 


### PR DESCRIPTION
## Summary

- macOS ships bash 3.2 which lacks the `mapfile` builtin (bash 4+)
- Every `shiv update`, `shiv uninstall`, and `shiv doctor` run printed `mapfile: command not found` on stderr
- Replaced all 9 `mapfile` calls with portable `while IFS= read -r` loops — 3 in runtime scripts, 6 in BATS tests

## Test plan

- [x] `shiv update` runs clean — no `mapfile` errors
- [x] `shiv doctor` runs clean
- [ ] BATS test suite passes (`mise run test`)