### PR TITLE
fix: always set CALLER_PWD to current $PWD in shims

### DIFF
--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -39,7 +39,7 @@ if [ ! -d "\$REPO" ]; then
   echo "$name: run 'shiv doctor' to diagnose" >&2
   exit 1
 fi
-export CALLER_PWD="\${CALLER_PWD:-\$PWD}"
+export CALLER_PWD="\$PWD"
 if [ "\$(basename "\$PWD")" = "$name" ] && [ "\$PWD" != "$repo_dir" ]; then
   echo "$name: warning: you're in a directory called '$name' but running the shiv-installed copy" >&2
   echo "$name: shiv package: $repo_dir" >&2

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -61,31 +61,31 @@ TASK
 # CALLER_PWD propagation
 # ============================================================================
 
-@test "shim: template uses conditional CALLER_PWD assignment" {
+@test "shim: template uses unconditional CALLER_PWD assignment" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
 
-  grep -q 'CALLER_PWD="${CALLER_PWD:-$PWD}"' "$SHIV_BIN_DIR/myapp"
+  grep -q 'CALLER_PWD="$PWD"' "$SHIV_BIN_DIR/myapp"
 }
 
-@test "shim: defaults CALLER_PWD to PWD when not pre-set" {
+@test "shim: CALLER_PWD reflects actual cwd" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
 
-  run bash -c "unset CALLER_PWD; cd /tmp && '$SHIV_BIN_DIR/myapp' show-caller"
+  run bash -c "cd /tmp && '$SHIV_BIN_DIR/myapp' show-caller"
   [ "$status" -eq 0 ]
   [[ "$output" == *"/tmp"* ]]
 }
 
-@test "shim: preserves CALLER_PWD set by upstream package" {
+@test "shim: CALLER_PWD overrides stale value from environment" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
 
-  # Simulate cross-package call: upstream shim already set CALLER_PWD
-  run bash -c "export CALLER_PWD='/some/upstream/dir' && '$SHIV_BIN_DIR/myapp' show-caller"
+  # Even if CALLER_PWD is set in the environment, the shim should use $PWD
+  run bash -c "export CALLER_PWD='/some/stale/dir' && cd /tmp && '$SHIV_BIN_DIR/myapp' show-caller"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"/some/upstream/dir"* ]]
+  [[ "$output" == *"/tmp"* ]]
 }


### PR DESCRIPTION
## Summary

- Shim template now uses `export CALLER_PWD="$PWD"` instead of `export CALLER_PWD="${CALLER_PWD:-$PWD}"`
- Prevents stale `CALLER_PWD` values from leaking through long-lived sessions

**Root cause:** `shimmer agent:local` launches claude via `exec`, which inherits the full environment. The shiv shim for shimmer had already set `CALLER_PWD` to the session start directory. Every subsequent shiv tool invocation preserved that stale value instead of using the actual cwd.

**Example:** Running `readme build` from `~/agents/baby-joel/chat` would look for `README.tsx` in `~/agents/or/den` (where the session started).

## Test plan

- [x] All 157 shiv tests pass (8 suites)
- [x] 3 CALLER_PWD-specific tests updated to match new behavior
- [ ] After merge + `shiv update shiv`, verify `readme build` works from any directory