### PR TITLE
fix: pin GH_HOST=github.com in install task

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -5,6 +5,10 @@
 #USAGE flag "--as <alias>" var=#true help="Command alias(es) — creates symlinks to the package shim"
 set -eo pipefail
 
+# shiv packages live on github.com. Pin GH_HOST so `gh repo clone` doesn't
+# resolve against a GHE instance when the user's default host is corporate.
+export GH_HOST=github.com
+
 REPO_DIR="$MISE_CONFIG_ROOT"
 source "$REPO_DIR/lib/shim.sh"
 


### PR DESCRIPTION
When a user's `gh` CLI defaults to a GHE instance (e.g. via `GH_HOST`), `gh repo clone` resolves package slugs against the wrong host, producing `GraphQL: Could not resolve to a Repository` errors.

Pins `GH_HOST=github.com` at the top of the install script since all shiv packages live on github.com.

**Ref:** Torbit/okwai#296
**Tests:** 206/206 passing