### PR TITLE
feat: add mise shims to PATH in shell init

### DIFF
--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -25,23 +25,8 @@ if [ -z "$EXISTING_SHIV" ]; then
   shiv_cache_tasks "shiv" "$SHIV_CANONICAL"
 fi
 
-# Ensure ~/.local/bin is on PATH (skip if already there)
-case ":$PATH:" in
-  *":$SHIV_BIN_DIR:"*) ;;
-  *) echo "export PATH=\"$SHIV_BIN_DIR:\$PATH\"" ;;
-esac
-
-# Ensure mise shims are on PATH so shiv packages installed via vfox-shiv
-# resolve correctly in non-interactive shells (agent sessions, scripts, etc.).
-# Emitted after SHIV_BIN_DIR so shims end up earlier on PATH — when a
-# directory's mise.toml pins a version, the mise shim wins over the global shiv shim.
-MISE_SHIMS_DIR="${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims"
-if [ -d "$MISE_SHIMS_DIR" ]; then
-  case ":$PATH:" in
-    *":$MISE_SHIMS_DIR:"*) ;;
-    *) echo "export PATH=\"$MISE_SHIMS_DIR:\$PATH\"" ;;
-  esac
-fi
+# Emit PATH exports for shiv bin dir and mise shims
+shiv_emit_path_exports
 
 # Export SHIV_SOURCES if sources directory has files
 if [ -n "$SHIV_SOURCES" ]; then

--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -31,6 +31,18 @@ case ":$PATH:" in
   *) echo "export PATH=\"$SHIV_BIN_DIR:\$PATH\"" ;;
 esac
 
+# Ensure mise shims are on PATH so shiv packages installed via vfox-shiv
+# resolve correctly in non-interactive shells (agent sessions, scripts, etc.).
+# Emitted after SHIV_BIN_DIR so shims end up earlier on PATH — when a
+# directory's mise.toml pins a version, the mise shim wins over the global shiv shim.
+MISE_SHIMS_DIR="${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims"
+if [ -d "$MISE_SHIMS_DIR" ]; then
+  case ":$PATH:" in
+    *":$MISE_SHIMS_DIR:"*) ;;
+    *) echo "export PATH=\"$MISE_SHIMS_DIR:\$PATH\"" ;;
+  esac
+fi
+
 # Export SHIV_SOURCES if sources directory has files
 if [ -n "$SHIV_SOURCES" ]; then
   echo "export SHIV_SOURCES=\"$SHIV_SOURCES\""

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -169,6 +169,29 @@ shiv_create_alias_symlinks() {
   done
 }
 
+# Emit shell export statements to put shiv's bin dir and mise's shims dir on PATH.
+# Designed to be eval'd: `eval "$(shiv_emit_path_exports)"`
+# Mise shims are emitted after SHIV_BIN_DIR so they end up first on PATH —
+# when a directory's mise.toml pins a version, the mise shim wins over the
+# global shiv shim.
+shiv_emit_path_exports() {
+  # Ensure SHIV_BIN_DIR (~/.local/bin) is on PATH
+  case ":$PATH:" in
+    *":$SHIV_BIN_DIR:"*) ;;
+    *) echo "export PATH=\"$SHIV_BIN_DIR:\$PATH\"" ;;
+  esac
+
+  # Ensure mise shims are on PATH so shiv packages installed via vfox-shiv
+  # resolve correctly in non-interactive shells (agent sessions, scripts, etc.).
+  local mise_shims_dir="${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims"
+  if [ -d "$mise_shims_dir" ]; then
+    case ":$PATH:" in
+      *":$mise_shims_dir:"*) ;;
+      *) echo "export PATH=\"$mise_shims_dir:\$PATH\"" ;;
+    esac
+  fi
+}
+
 # Remove alias symlinks for a package (only if they point to the expected target)
 shiv_remove_alias_symlinks() {
   local name="$1"

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -1,9 +1,5 @@
 #!/usr/bin/env bats
 # shiv shell task tests — PATH setup for shiv + mise shims
-#
-# Tests the PATH-emitting logic from the shell task directly,
-# without running through `mise run` (which requires trust/install
-# of the full global config and is slow in test).
 
 REPO_DIR="$BATS_TEST_DIRNAME/.."
 load helpers
@@ -30,29 +26,6 @@ teardown() {
   rm -rf "$TEST_HOME"
 }
 
-# Helper: run just the PATH-emitting logic from the shell task.
-# This avoids needing mise trust/install for the global config.
-run_shell_path_logic() {
-  bash -c '
-    source "'"$REPO_DIR"'/lib/shim.sh"
-
-    # Ensure ~/.local/bin is on PATH (skip if already there)
-    case ":$PATH:" in
-      *":$SHIV_BIN_DIR:"*) ;;
-      *) echo "export PATH=\"$SHIV_BIN_DIR:\$PATH\"" ;;
-    esac
-
-    # Ensure mise shims are on PATH
-    MISE_SHIMS_DIR="${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims"
-    if [ -d "$MISE_SHIMS_DIR" ]; then
-      case ":$PATH:" in
-        *":$MISE_SHIMS_DIR:"*) ;;
-        *) echo "export PATH=\"$MISE_SHIMS_DIR:\$PATH\"" ;;
-      esac
-    fi
-  '
-}
-
 # ============================================================================
 # SHIV_BIN_DIR on PATH
 # ============================================================================
@@ -60,7 +33,7 @@ run_shell_path_logic() {
 @test "shell: adds SHIV_BIN_DIR to PATH when not present" {
   export PATH="${PATH//$SHIV_BIN_DIR:/}"
 
-  run run_shell_path_logic
+  run shiv_emit_path_exports
   [ "$status" -eq 0 ]
   [[ "$output" == *"export PATH=\"$SHIV_BIN_DIR:"* ]]
 }
@@ -68,7 +41,7 @@ run_shell_path_logic() {
 @test "shell: skips SHIV_BIN_DIR when already on PATH" {
   export PATH="$SHIV_BIN_DIR:$PATH"
 
-  run run_shell_path_logic
+  run shiv_emit_path_exports
   [ "$status" -eq 0 ]
   [[ "$output" != *"export PATH=\"$SHIV_BIN_DIR:"* ]]
 }
@@ -82,7 +55,7 @@ run_shell_path_logic() {
   mkdir -p "$shims_dir"
   export PATH="${PATH//$shims_dir:/}"
 
-  run run_shell_path_logic
+  run shiv_emit_path_exports
   [ "$status" -eq 0 ]
   [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
 }
@@ -92,13 +65,13 @@ run_shell_path_logic() {
   mkdir -p "$shims_dir"
   export PATH="$shims_dir:$PATH"
 
-  run run_shell_path_logic
+  run shiv_emit_path_exports
   [ "$status" -eq 0 ]
   [[ "$output" != *"export PATH=\"$shims_dir:"* ]]
 }
 
 @test "shell: skips mise shims dir when it does not exist" {
-  run run_shell_path_logic
+  run shiv_emit_path_exports
   [ "$status" -eq 0 ]
   [[ "$output" != *"mise/shims"* ]]
 }
@@ -109,10 +82,9 @@ run_shell_path_logic() {
   export PATH="${PATH//$SHIV_BIN_DIR:/}"
   export PATH="${PATH//$shims_dir:/}"
 
-  run run_shell_path_logic
+  run shiv_emit_path_exports
   [ "$status" -eq 0 ]
 
-  # Both should be present
   [[ "$output" == *"$SHIV_BIN_DIR"* ]]
   [[ "$output" == *"$shims_dir"* ]]
 
@@ -130,7 +102,7 @@ run_shell_path_logic() {
   mkdir -p "$shims_dir"
   export MISE_DATA_DIR="$custom_mise"
 
-  run run_shell_path_logic
+  run shiv_emit_path_exports
   [ "$status" -eq 0 ]
   [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
 }
@@ -142,7 +114,7 @@ run_shell_path_logic() {
   export XDG_DATA_HOME="$xdg_data"
   unset MISE_DATA_DIR
 
-  run run_shell_path_logic
+  run shiv_emit_path_exports
   [ "$status" -eq 0 ]
   [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
 }
@@ -157,8 +129,7 @@ run_shell_path_logic() {
   export PATH="${PATH//$SHIV_BIN_DIR:/}"
   export PATH="${PATH//$shims_dir:/}"
 
-  # Eval the output and check resulting PATH
-  eval "$(run_shell_path_logic)"
+  eval "$(shiv_emit_path_exports)"
 
   # mise shims should come before SHIV_BIN_DIR
   local shims_pos bin_pos

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# shiv shell task tests — PATH setup for shiv + mise shims
+#
+# Tests the PATH-emitting logic from the shell task directly,
+# without running through `mise run` (which requires trust/install
+# of the full global config and is slow in test).
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+load helpers
+
+setup() {
+  source "$REPO_DIR/lib/shim.sh"
+
+  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  mkdir -p "$TEST_HOME"
+
+  export HOME="$TEST_HOME"
+  export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
+  export SHIV_DATA_DIR="$TEST_HOME/.local/share/shiv"
+  export SHIV_PACKAGES_DIR="$SHIV_DATA_DIR/packages"
+  export SHIV_CONFIG_DIR="$TEST_HOME/.config/shiv"
+  export SHIV_CACHE_DIR="$TEST_HOME/.cache/shiv"
+  export SHIV_REGISTRY="$SHIV_CONFIG_DIR/registry.json"
+
+  mkdir -p "$SHIV_BIN_DIR"
+  shiv_init_registry
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# Helper: run just the PATH-emitting logic from the shell task.
+# This avoids needing mise trust/install for the global config.
+run_shell_path_logic() {
+  bash -c '
+    source "'"$REPO_DIR"'/lib/shim.sh"
+
+    # Ensure ~/.local/bin is on PATH (skip if already there)
+    case ":$PATH:" in
+      *":$SHIV_BIN_DIR:"*) ;;
+      *) echo "export PATH=\"$SHIV_BIN_DIR:\$PATH\"" ;;
+    esac
+
+    # Ensure mise shims are on PATH
+    MISE_SHIMS_DIR="${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims"
+    if [ -d "$MISE_SHIMS_DIR" ]; then
+      case ":$PATH:" in
+        *":$MISE_SHIMS_DIR:"*) ;;
+        *) echo "export PATH=\"$MISE_SHIMS_DIR:\$PATH\"" ;;
+      esac
+    fi
+  '
+}
+
+# ============================================================================
+# SHIV_BIN_DIR on PATH
+# ============================================================================
+
+@test "shell: adds SHIV_BIN_DIR to PATH when not present" {
+  export PATH="${PATH//$SHIV_BIN_DIR:/}"
+
+  run run_shell_path_logic
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"export PATH=\"$SHIV_BIN_DIR:"* ]]
+}
+
+@test "shell: skips SHIV_BIN_DIR when already on PATH" {
+  export PATH="$SHIV_BIN_DIR:$PATH"
+
+  run run_shell_path_logic
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"export PATH=\"$SHIV_BIN_DIR:"* ]]
+}
+
+# ============================================================================
+# Mise shims on PATH
+# ============================================================================
+
+@test "shell: adds mise shims dir to PATH when present on disk" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+  mkdir -p "$shims_dir"
+  export PATH="${PATH//$shims_dir:/}"
+
+  run run_shell_path_logic
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
+}
+
+@test "shell: skips mise shims dir when already on PATH" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+  mkdir -p "$shims_dir"
+  export PATH="$shims_dir:$PATH"
+
+  run run_shell_path_logic
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"export PATH=\"$shims_dir:"* ]]
+}
+
+@test "shell: skips mise shims dir when it does not exist" {
+  run run_shell_path_logic
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"mise/shims"* ]]
+}
+
+@test "shell: mise shims emitted after SHIV_BIN_DIR (ends up first on PATH)" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+  mkdir -p "$shims_dir"
+  export PATH="${PATH//$SHIV_BIN_DIR:/}"
+  export PATH="${PATH//$shims_dir:/}"
+
+  run run_shell_path_logic
+  [ "$status" -eq 0 ]
+
+  # Both should be present
+  [[ "$output" == *"$SHIV_BIN_DIR"* ]]
+  [[ "$output" == *"$shims_dir"* ]]
+
+  # SHIV_BIN_DIR should appear before mise shims in output
+  # (since both prepend, the later one ends up first on PATH)
+  local bin_line shims_line
+  bin_line=$(echo "$output" | grep -n "$SHIV_BIN_DIR" | head -1 | cut -d: -f1)
+  shims_line=$(echo "$output" | grep -n "mise/shims" | head -1 | cut -d: -f1)
+  [ "$bin_line" -lt "$shims_line" ]
+}
+
+@test "shell: respects MISE_DATA_DIR for shims path" {
+  local custom_mise="$TEST_HOME/custom-mise"
+  local shims_dir="$custom_mise/shims"
+  mkdir -p "$shims_dir"
+  export MISE_DATA_DIR="$custom_mise"
+
+  run run_shell_path_logic
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
+}
+
+@test "shell: respects XDG_DATA_HOME for shims path" {
+  local xdg_data="$TEST_HOME/xdg-data"
+  local shims_dir="$xdg_data/mise/shims"
+  mkdir -p "$shims_dir"
+  export XDG_DATA_HOME="$xdg_data"
+  unset MISE_DATA_DIR
+
+  run run_shell_path_logic
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
+}
+
+# ============================================================================
+# End-to-end: eval output produces correct PATH ordering
+# ============================================================================
+
+@test "shell: eval output puts mise shims before SHIV_BIN_DIR on PATH" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+  mkdir -p "$shims_dir"
+  export PATH="${PATH//$SHIV_BIN_DIR:/}"
+  export PATH="${PATH//$shims_dir:/}"
+
+  # Eval the output and check resulting PATH
+  eval "$(run_shell_path_logic)"
+
+  # mise shims should come before SHIV_BIN_DIR
+  local shims_pos bin_pos
+  shims_pos=$(echo "$PATH" | tr ':' '\n' | grep -n "mise/shims" | head -1 | cut -d: -f1)
+  bin_pos=$(echo "$PATH" | tr ':' '\n' | grep -n "$SHIV_BIN_DIR" | head -1 | cut -d: -f1)
+  [ "$shims_pos" -lt "$bin_pos" ]
+}


### PR DESCRIPTION
## Problem

Shiv packages installed via mise's vfox-shiv backend are only on PATH in directories where a `mise.toml` lists them — and only when mise's shell hook fires. Non-interactive shells (agent sessions via pi, scripts, subprocesses) never trigger the hook, so they resolve to global shiv shims in `~/.local/bin`, ignoring per-project version pins.

This means if two codebases pin different versions of a shiv package (e.g., `shimmer v1` vs `shimmer v2`), the wrong version runs in agent sessions.

## Fix

The `shell` task now also prepends mise's shims directory to PATH. Mise shims are binaries that handle version resolution themselves — they read the nearest `mise.toml` and run the correct version. This works in any shell context without requiring `mise activate`.

- Emitted **after** `SHIV_BIN_DIR` so shims end up **first** on PATH — mise-pinned versions win over global shiv shims
- Guarded by `-d` check — no-op if mise isn't installed
- Respects `MISE_DATA_DIR` and `XDG_DATA_HOME`
- Applies automatically to any shell that evals `shiv run shell` (interactive, agent, etc.)

## Tests

9 new tests in `test/shell.bats` covering PATH addition, skip-when-present, ordering, absence, and `MISE_DATA_DIR`/`XDG_DATA_HOME` override. Full suite: 229/229 passing.