### PR TITLE
feat: add mise.prod.toml for runtime-only dependencies

### DIFF
--- a/mise.prod.toml
+++ b/mise.prod.toml
@@ -1,0 +1,6 @@
+# Runtime-only tools — used by consumers (e.g., vfox-shiv bootstrap).
+# Dev/test tools (bats, jsonschema) stay in mise.toml.
+# Usage: MISE_ENV=prod mise install
+
+[tools]
+gum = "0.17.0"


### PR DESCRIPTION
Separates runtime tools (gum) from dev/test tools (bats, jsonschema). Consumers like vfox-shiv can bootstrap with `MISE_ENV=prod` to install only what's needed to run shiv.

**Why:** vfox-shiv bootstraps shiv by running `mise install` on the clone. This installs everything including bats, which fails on some CI runners (aqua backend 404 on bats archive). With this split, vfox-shiv sets `MISE_ENV=prod` and only installs gum.

**No change for devs** — `mise install` still installs everything from `mise.toml`. `mise.prod.toml` is only used when explicitly requested.