### PR TITLE
fix: fail fast on dependency install

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -114,7 +114,11 @@ else
 
   # Set up dependencies
   printf -v escaped_path '%q' "$TOOL_PATH"
-  gum spin --title "  Setting up dependencies..." -- bash -c "cd $escaped_path && mise trust -q 2>/dev/null; mise install -q 2>/dev/null || true"
+  dep_output=$(bash -c "cd $escaped_path && mise trust -q 2>/dev/null; mise install -q 2>&1") || {
+    echo "  ✗ Failed to install dependencies for $NAME" >&2
+    echo "$dep_output" | sed 's/^/    /' >&2
+    exit 1
+  }
 fi
 
 if [ ! -f "$TOOL_PATH/mise.toml" ]; then

--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -11,6 +11,7 @@ export GH_HOST=github.com
 
 REPO_DIR="$MISE_CONFIG_ROOT"
 source "$REPO_DIR/lib/shim.sh"
+source "$REPO_DIR/lib/format.sh"
 
 NAME="${usage_name}"
 LOCAL_PATH="${usage_path:-}"
@@ -116,7 +117,7 @@ else
   printf -v escaped_path '%q' "$TOOL_PATH"
   dep_output=$(gum spin --title "  Setting up dependencies..." -- bash -c "cd $escaped_path && mise trust -q 2>&1 && mise install -q 2>&1") || {
     echo "  ✗ Failed to install dependencies for $NAME" >&2
-    echo "$dep_output" | sed $'s/\x1b\\[[0-9;]*m//g' | sed 's/^/    /' >&2
+    echo "$dep_output" | strip_ansi | sed 's/^/    /' >&2
     exit 1
   }
 fi

--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -114,9 +114,9 @@ else
 
   # Set up dependencies
   printf -v escaped_path '%q' "$TOOL_PATH"
-  dep_output=$(bash -c "cd $escaped_path && mise trust -q 2>/dev/null; mise install -q 2>&1") || {
+  dep_output=$(gum spin --title "  Setting up dependencies..." -- bash -c "cd $escaped_path && mise trust -q 2>&1 && mise install -q 2>&1") || {
     echo "  ✗ Failed to install dependencies for $NAME" >&2
-    echo "$dep_output" | sed 's/^/    /' >&2
+    echo "$dep_output" | sed $'s/\x1b\\[[0-9;]*m//g' | sed 's/^/    /' >&2
     exit 1
   }
 fi

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,21 +1,35 @@
 #!/usr/bin/env bash
-#MISE description="Run test suite"
-#USAGE arg "[name]" help="Test file to run (e.g. 'list' for test/list.bats). Runs all if omitted."
-set -eo pipefail
+#MISE description="Run BATS tests"
+#USAGE arg "[args]..." var=#true help="Test suites or bats arguments"
+#USAGE example "mise run test" header="Run all tests"
+#USAGE example "mise run test doctor" header="Run a specific suite by name"
+#USAGE example "mise run test test/format.bats" header="Run a specific file"
+#USAGE example "mise run test -- --filter rejects" header="Filter tests by name"
+set -euo pipefail
 
-REPO_DIR="$MISE_CONFIG_ROOT"
+TEST_DIR="$MISE_CONFIG_ROOT/test"
 
-# Completions excluded — requires fish/zsh, has its own workflow
+# Completions excluded from default run — requires fish/zsh, has its own workflow
 EXCLUDE="completions"
 
-if [[ -n "${usage_name:-}" ]]; then
-  bats "$REPO_DIR/test/${usage_name}.bats"
-else
-  files=()
-  for f in "$REPO_DIR"/test/*.bats; do
-    name="$(basename "$f" .bats)"
-    [[ "$name" == "$EXCLUDE" ]] && continue
-    files+=("$f")
+args=()
+has_target=false
+
+for arg in "$@"; do
+  if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
+    args+=("$TEST_DIR/$arg.bats")
+    has_target=true
+  else
+    [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+    args+=("$arg")
+  fi
+done
+
+if ! $has_target; then
+  for f in "$TEST_DIR"/*.bats; do
+    [[ "$(basename "$f" .bats)" == "$EXCLUDE" ]] && continue
+    args+=("$f")
   done
-  bats "${files[@]}"
 fi
+
+bats "${args[@]}"

--- a/lib/format.sh
+++ b/lib/format.sh
@@ -1,0 +1,8 @@
+# Formatting utilities for shiv output
+
+# strip_ansi — Remove ANSI escape codes from text
+# Handles color codes (\e[...m), cursor control, and mode sequences.
+# Usage: echo "$colored_output" | strip_ansi
+strip_ansi() {
+  sed $'s/\x1b\\[[0-9;]*[A-Za-z]//g'
+}

--- a/lib/format.sh
+++ b/lib/format.sh
@@ -4,5 +4,5 @@
 # Handles color codes (\e[...m), cursor control, and mode sequences.
 # Usage: echo "$colored_output" | strip_ansi
 strip_ansi() {
-  sed $'s/\x1b\\[[0-9;]*[A-Za-z]//g'
+  sed $'s/\x1b\\[[?]*[0-9;]*[A-Za-z]//g'
 }

--- a/test/format.bats
+++ b/test/format.bats
@@ -35,3 +35,9 @@ setup() {
   result=$(echo "$input" | strip_ansi)
   [ "$result" = "helloworld" ]
 }
+
+@test "strip_ansi removes terminal mode sequences" {
+  input=$'\e[?25l\e[?2004hvisible text\e[?25h\e[?2004l'
+  result=$(echo "$input" | strip_ansi)
+  [ "$result" = "visible text" ]
+}

--- a/test/format.bats
+++ b/test/format.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# Tests for lib/format.sh utilities
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+
+setup() {
+  source "$REPO_DIR/lib/format.sh"
+}
+
+@test "strip_ansi removes color codes" {
+  input=$'\e[31mERROR\e[0m something broke'
+  result=$(echo "$input" | strip_ansi)
+  [ "$result" = "ERROR something broke" ]
+}
+
+@test "strip_ansi removes bold and combined codes" {
+  input=$'\e[1;33mWARNING\e[0m: check this'
+  result=$(echo "$input" | strip_ansi)
+  [ "$result" = "WARNING: check this" ]
+}
+
+@test "strip_ansi passes through plain text unchanged" {
+  input="no escape codes here"
+  result=$(echo "$input" | strip_ansi)
+  [ "$result" = "$input" ]
+}
+
+@test "strip_ansi handles empty input" {
+  result=$(echo "" | strip_ansi)
+  [ "$result" = "" ]
+}
+
+@test "strip_ansi removes cursor movement codes" {
+  input=$'\e[2Khello\e[1Aworld'
+  result=$(echo "$input" | strip_ansi)
+  [ "$result" = "helloworld" ]
+}


### PR DESCRIPTION
Replace `mise install -q || true` with proper error handling in the install task.

Before: dep install failures were silently swallowed, causing confusing failures later when tasks run without their dependencies (e.g. shimmer tasks failing because shiv:codebase wasn't installed).

After: dep install failures are surfaced immediately with the actual error message, and the install aborts.

Related: vfox-shiv error cleanup in KnickKnackLabs/vfox-shiv#6.