### PR TITLE
Fix: _default task + subtask ambiguity in shim dispatch

### DIFF
--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -127,21 +127,50 @@ case "\${1:-}" in
     _shiv_handle_tasks "\$@"
     ;;
   *)
-    # Default task takes priority over space resolution — tools with a
-    # default task are single-command wrappers that pass all args through.
+    # --- Default task handling ---
+    # No args: run default task directly.
     if [ -n "\$DEFAULT_TASK" ] && [ -z "\${1:-}" ]; then
       exec mise -C "\$REPO" run -q "\$DEFAULT_TASK"
-    elif [ -n "\$DEFAULT_TASK" ]; then
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$@"
     fi
+
+    # "--" as first arg: explicit disambiguation — send everything
+    # after "--" to the default task.
+    if [ -n "\$DEFAULT_TASK" ] && [ "\${1:-}" = "--" ]; then
+      shift
+      if [ \$# -gt 0 ]; then
+        exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$@"
+      else
+        exec mise -C "\$REPO" run -q "\$DEFAULT_TASK"
+      fi
+    fi
+
+    # Check if "--" is present in args (user is disambiguating).
+    _shiv_has_dash=false
+    for _shiv_arg in "\$@"; do
+      if [ "\$_shiv_arg" = "--" ]; then
+        _shiv_has_dash=true
+        break
+      fi
+    done
 
     # Space-to-colon resolution
     _shiv_ensure_task_map
     shiv_resolve_task "$name" "\$SHIV_TASK_MAP" "\$@"
     _shiv_rc=\$?
     if [ "\$_shiv_rc" -eq 0 ]; then
+      # Resolved a subtask. If a default task also exists and the user
+      # didn't use "--" to disambiguate, this is ambiguous.
+      if [ -n "\$DEFAULT_TASK" ] && [ "\$_shiv_has_dash" = "false" ]; then
+        echo "Ambiguous: '\$*' could be:" >&2
+        echo "  task '\$SHIV_RESOLVED_TASK' with args: \${SHIV_RESOLVED_ARGS[*]:-<none>}" >&2
+        echo "  default task with args: \$*" >&2
+        echo "Use -- to disambiguate:" >&2
+        echo "  $name \${SHIV_RESOLVED_TASK//:/ } -- \${SHIV_RESOLVED_ARGS[*]}     (task '\$SHIV_RESOLVED_TASK')" >&2
+        echo "  $name -- \$*     (default task)" >&2
+        exit 1
+      fi
       # Guard: only expand SHIV_RESOLVED_ARGS when non-empty.
-      # bash <4.4 treats "${empty_array[@]}" as unbound under set -u.
+      # bash <4.4 treats "\${empty_array[@]}" as unbound under set -u.
       if [ \${#SHIV_RESOLVED_ARGS[@]} -gt 0 ]; then
         exec mise -C "\$REPO" run -q "\$SHIV_RESOLVED_TASK" "\${SHIV_RESOLVED_ARGS[@]}"
       else
@@ -150,7 +179,10 @@ case "\${1:-}" in
     elif [ "\$_shiv_rc" -eq 1 ]; then
       exit 1  # ambiguous — error already printed to stderr
     fi
-    # rc=2 or no task map: fall through to mise
+    # rc=2 or no task map: fall through to default task or mise
+    if [ -n "\$DEFAULT_TASK" ]; then
+      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$@"
+    fi
     exec mise -C "\$REPO" run -q "\$@"
     ;;
 esac

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -280,3 +280,142 @@ populate_task_map() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"DEV_TEST_UNIT"* ]]
 }
+
+# ============================================================================
+# Default task + subtask ambiguity (shiv#94)
+# ============================================================================
+
+# Helper: create a repo with _default (interactive menu) + named subtasks.
+# Mimics the pattern from KnickKnackLabs/ask.
+create_default_plus_subtasks_repo() {
+  local name="$1"
+  local repo_dir="$TEST_HOME/repos/$name"
+
+  mkdir -p "$repo_dir/.mise/tasks"
+  git -C "$repo_dir" init -q -b main
+  git -C "$repo_dir" config user.email "test@test.com"
+  git -C "$repo_dir" config user.name "Test"
+
+  echo '[tools]' > "$repo_dir/mise.toml"
+
+  # _default — interactive menu / catch-all
+  cat > "$repo_dir/.mise/tasks/_default" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Interactive menu"
+echo "DEFAULT $*"
+TASK
+  chmod +x "$repo_dir/.mise/tasks/_default"
+
+  # question — named subtask (alias: q)
+  cat > "$repo_dir/.mise/tasks/question" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Ask a question"
+#MISE alias="q"
+echo "QUESTION $*"
+TASK
+  chmod +x "$repo_dir/.mise/tasks/question"
+
+  # info — another named subtask
+  cat > "$repo_dir/.mise/tasks/info" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Show info"
+echo "INFO $*"
+TASK
+  chmod +x "$repo_dir/.mise/tasks/info"
+
+  git -C "$repo_dir" add .
+  git -C "$repo_dir" commit -q -m "init"
+  mise trust "$repo_dir/mise.toml" 2>/dev/null
+
+  echo "$repo_dir"
+}
+
+@test "shim: _default runs with no args" {
+  local repo_dir
+  repo_dir=$(create_default_plus_subtasks_repo "asktool")
+  shiv install asktool "$repo_dir" 2>/dev/null
+  populate_task_map "asktool" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/asktool"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEFAULT"* ]]
+}
+
+@test "shim: subtask name is ambiguous when _default exists" {
+  local repo_dir
+  repo_dir=$(create_default_plus_subtasks_repo "asktool")
+  shiv install asktool "$repo_dir" 2>/dev/null
+  populate_task_map "asktool" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/asktool" question hello
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Ambiguous"* ]]
+  [[ "$output" == *"--"* ]]
+}
+
+@test "shim: subtask alone is ambiguous when _default exists" {
+  local repo_dir
+  repo_dir=$(create_default_plus_subtasks_repo "asktool")
+  shiv install asktool "$repo_dir" 2>/dev/null
+  populate_task_map "asktool" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/asktool" info
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Ambiguous"* ]]
+}
+
+@test "shim: -- before subtask name routes to _default" {
+  local repo_dir
+  repo_dir=$(create_default_plus_subtasks_repo "asktool")
+  shiv install asktool "$repo_dir" 2>/dev/null
+  populate_task_map "asktool" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/asktool" -- question hello
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEFAULT question hello"* ]]
+}
+
+@test "shim: subtask -- args routes to subtask" {
+  local repo_dir
+  repo_dir=$(create_default_plus_subtasks_repo "asktool")
+  shiv install asktool "$repo_dir" 2>/dev/null
+  populate_task_map "asktool" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/asktool" question -- hello
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"QUESTION"* ]]
+  [[ "$output" == *"hello"* ]]
+}
+
+@test "shim: unrecognized arg falls through to _default" {
+  local repo_dir
+  repo_dir=$(create_default_plus_subtasks_repo "asktool")
+  shiv install asktool "$repo_dir" 2>/dev/null
+  populate_task_map "asktool" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/asktool" "summarize this"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEFAULT summarize this"* ]]
+}
+
+@test "shim: flag args fall through to _default" {
+  local repo_dir
+  repo_dir=$(create_default_plus_subtasks_repo "asktool")
+  shiv install asktool "$repo_dir" 2>/dev/null
+  populate_task_map "asktool" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/asktool" -m sonnet
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEFAULT -m sonnet"* ]]
+}
+
+@test "shim: -- with no further args runs _default with no args" {
+  local repo_dir
+  repo_dir=$(create_default_plus_subtasks_repo "asktool")
+  shiv install asktool "$repo_dir" 2>/dev/null
+  populate_task_map "asktool" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/asktool" --
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEFAULT"* ]]
+}


### PR DESCRIPTION
## Problem (shiv#94)

When a package has both `_default` and named subtasks (e.g. `ask` has `_default` for interactive menu + `question`/`q` for direct queries), the shim routes **all** arguments through `_default`. Subtasks are unreachable:

```
ask q "what is a mutex"
# actual:   mise run _default q "what is a mutex"
# expected: error or question task
```

## Fix

Flip the resolution order in the shim dispatch logic:

1. **No args** → `_default` (unchanged)
2. **`--` as first arg** → strip `--`, send remaining to `_default`
3. **Args present** → try space-to-colon resolution first:
   - If subtask matches AND `_default` exists AND no `--` in args → **ambiguous, fail with guidance**
   - If subtask matches AND `--` present → user disambiguated, run subtask
   - If no match AND `_default` exists → fall through to `_default "$@"`
   - If already ambiguous between tasks (rc=1) → exit 1 (existing behavior)
4. **No `DEFAULT_TASK`** → existing behavior unchanged

## Disambiguation with `--`

```
ask q -- hello        → task "question", args: hello
ask -- q hello        → _default, args: q hello
ask "summarize this"  → no subtask match → _default "summarize this"
ask -m sonnet         → no subtask match → _default -m sonnet
ask                   → _default with no args (unchanged)
ask q hello           → ambiguous, fail with guidance
```

This matches the existing pattern for task-group ambiguity (e.g. both `agent` and `agent:dispatch` are tasks).

## Tests

8 new tests covering all cases. 222/222 full suite green.

Closes #94