### PR TITLE
install: use git clone instead of gh repo clone

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -5,10 +5,6 @@
 #USAGE flag "--as <alias>" var=#true help="Command alias(es) — creates symlinks to the package shim"
 set -eo pipefail
 
-# shiv packages live on github.com. Pin GH_HOST so `gh repo clone` doesn't
-# resolve against a GHE instance when the user's default host is corporate.
-export GH_HOST=github.com
-
 REPO_DIR="$MISE_CONFIG_ROOT"
 source "$REPO_DIR/lib/shim.sh"
 source "$REPO_DIR/lib/format.sh"
@@ -95,18 +91,19 @@ else
     fi
   else
     mkdir -p "$SHIV_PACKAGES_DIR"
+    CLONE_URL="https://github.com/$GH_REPO.git"
     case "$REF_TYPE" in
       "")
-        gum spin --title "  Cloning $GH_REPO..." --show-error -- gh repo clone "$GH_REPO" "$TOOL_PATH" -- --single-branch
+        gum spin --title "  Cloning $GH_REPO..." --show-error -- git clone --single-branch "$CLONE_URL" "$TOOL_PATH"
         ;;
       branch)
-        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- gh repo clone "$GH_REPO" "$TOOL_PATH" -- --branch "$REF" --single-branch
+        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --branch "$REF" --single-branch "$CLONE_URL" "$TOOL_PATH"
         ;;
       tag)
-        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- gh repo clone "$GH_REPO" "$TOOL_PATH" -- --branch "$REF" --depth 1 --single-branch
+        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --branch "$REF" --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"
         ;;
       commit)
-        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- gh repo clone "$GH_REPO" "$TOOL_PATH" -- --depth 1 --single-branch
+        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"
         git -C "$TOOL_PATH" fetch --depth 1 origin "$REF" 2>&1 | sed 's/^/  /'
         git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
         ;;


### PR DESCRIPTION
## What

`.mise/tasks/install` now uses `git clone` directly instead of `gh repo clone`. Drops the unused `GH_HOST=github.com` pin.

## Why

Eliminates `gh` as a runtime dependency for shiv package installs. Surfaced as a follow-up from okwai #312 review — shiv consumers should not need gh installed just to install a package.

`gh repo clone <repo> <dir> -- <git-args>` is a thin wrapper: args after `--` are forwarded verbatim to `git clone`. The change is mechanical:

```diff
-gh repo clone "$GH_REPO" "$TOOL_PATH" -- --single-branch
+git clone --single-branch "https://github.com/$GH_REPO.git" "$TOOL_PATH"
```

The `GH_HOST=github.com` pin was defensive against gh resolving against a corporate GHE default host. No longer relevant now that we call git directly.

## Auth

- **Public repos** (all current shiv packages): work without auth over HTTPS.
- **Private repos**: rely on the user's standard git credential helpers (`gh auth setup-git` is the common path, `git-credential-osxkeychain` on macOS, etc.). Same auth path any `git clone` uses.

## Verification

All four clone variants run against real repos end-to-end:

| Ref type | Command                                                             | Result                       |
| -------- | ------------------------------------------------------------------- | ---------------------------- |
| (none)   | `git clone --single-branch <url> <dir>`                             | ✓ clones default branch      |
| branch   | `git clone --branch <ref> --single-branch <url> <dir>`              | ✓ clones branch              |
| tag      | `git clone --branch <ref> --depth 1 --single-branch <url> <dir>`    | ✓ clones tag (detached HEAD) |
| commit   | `git clone --depth 1 --single-branch` + `fetch --depth 1 origin` + `checkout` | ✓ (unchanged from before)    |

Full suite: 223/223 tests pass.