### PR TITLE
fix: resolve mise-scoped packages in shiv which

### DIFF
--- a/.github/workflows/test-completions.yml
+++ b/.github/workflows/test-completions.yml
@@ -14,6 +14,9 @@ on:
       - test/completions.bats
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   test-completions:
     strategy:

--- a/.mise/tasks/completions/bash
+++ b/.mise/tasks/completions/bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Output bash completion script"
 #MISE hide=true
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/shim.sh"
 
@@ -16,9 +16,11 @@ cat <<'HEADER'
 __shiv_rebuild_cache() {
   local name="$1" repo="$2" cache="$3"
   mkdir -p "$(dirname "$cache")"
-  mise tasks --json -C "$repo" 2>/dev/null \
+  if ! mise tasks --json -C "$repo" 2>/dev/null \
     | jq -r '.[] | select(.hide == false) | "\(.name)\t\(.description)"' \
-    > "$cache" 2>/dev/null || true
+    > "$cache" 2>/dev/null; then
+    rm -f "$cache"
+  fi
 }
 
 HEADER

--- a/.mise/tasks/completions/zsh
+++ b/.mise/tasks/completions/zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Output zsh completion script"
 #MISE hide=true
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/shim.sh"
 
@@ -19,9 +19,11 @@ cat <<'HEADER'
 __shiv_rebuild_cache() {
   local name="$1" repo="$2" cache="$3"
   mkdir -p "$(dirname "$cache")"
-  mise tasks --json -C "$repo" 2>/dev/null \
+  if ! mise tasks --json -C "$repo" 2>/dev/null \
     | jq -r '.[] | select(.hide == false) | "\(.name)\t\(.description)"' \
-    > "$cache" 2>/dev/null || true
+    > "$cache" 2>/dev/null; then
+    rm -f "$cache"
+  fi
 }
 
 HEADER

--- a/.mise/tasks/doctor
+++ b/.mise/tasks/doctor
@@ -75,7 +75,10 @@ else
 
     # Check shim points to right repo
     if [ -f "$SHIV_BIN_DIR/$name" ]; then
-      shim_repo=$(grep '^REPO=' "$SHIV_BIN_DIR/$name" 2>/dev/null | cut -d'"' -f2 || true)
+      shim_repo=""
+      if ! shim_repo=$(grep '^REPO=' "$SHIV_BIN_DIR/$name" 2>/dev/null | cut -d'"' -f2); then
+        shim_repo=""
+      fi
       if [ -n "$shim_repo" ] && [ "$shim_repo" != "$repo" ]; then
         issues+="    ✗ shim points to $shim_repo but registry says $repo"$'\n'
         issue_count=$((issue_count + 1))

--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -3,7 +3,7 @@
 #USAGE arg "<name>" help="Package name, optionally with ref (e.g., shimmer, frames@v1.0.0)"
 #USAGE arg "[path]" help="Local path to repo (optional — if omitted, clones from package index)"
 #USAGE flag "--as <alias>" var=#true help="Command alias(es) — creates symlinks to the package shim"
-set -eo pipefail
+set -euo pipefail
 
 REPO_DIR="$MISE_CONFIG_ROOT"
 source "$REPO_DIR/lib/shim.sh"
@@ -35,7 +35,9 @@ if [ -n "$LOCAL_PATH" ]; then
   TOOL_PATH="$(cd "$LOCAL_PATH" && pwd)"
 else
   # Package install — look up in sources and clone
-  GH_REPO=$(shiv_lookup "$NAME" || true)
+  if ! GH_REPO=$(shiv_lookup "$NAME"); then
+    GH_REPO=""
+  fi
   if [ -z "$GH_REPO" ]; then
     echo "" >&2
     echo "  ✗ '$NAME' not found in package index" >&2
@@ -124,12 +126,16 @@ if [ ! -f "$TOOL_PATH/mise.toml" ]; then
 fi
 
 shiv_create_shim "$NAME" "$TOOL_PATH"
-SHIV_REF="$REF" shiv_register "$NAME" "$TOOL_PATH" "${ALIASES[@]}"
+if [ -n "${usage_as:-}" ]; then
+  SHIV_REF="$REF" shiv_register "$NAME" "$TOOL_PATH" "${ALIASES[@]}"
+else
+  SHIV_REF="$REF" shiv_register "$NAME" "$TOOL_PATH"
+fi
 shiv_cache_tasks "$NAME" "$TOOL_PATH"
 shiv_cache_task_map "$NAME" "$TOOL_PATH"
 
 # Create alias symlinks
-if [ ${#ALIASES[@]} -gt 0 ]; then
+if [ -n "${usage_as:-}" ]; then
   shiv_create_alias_symlinks "$NAME" "${ALIASES[@]}"
 fi
 
@@ -188,8 +194,10 @@ if [ -f "$cache_file" ]; then
 fi
 
 # Format aliases
-alias_display="${ALIASES[*]}"
-alias_display="${alias_display:--}"
+alias_display="-"
+if [ -n "${usage_as:-}" ]; then
+  alias_display="${ALIASES[*]}"
+fi
 
 # Build summary card as key-value table
 {

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -7,7 +7,9 @@ echo "Setting up $(basename "$MISE_CONFIG_ROOT")..."
 # Install codebase via shiv directly (not vfox-shiv) to avoid circular dependency:
 # shiv can't depend on vfox-shiv to install its own packages.
 if command -v shiv &>/dev/null; then
-  shiv install codebase 2>/dev/null || true
+  if ! shiv install codebase 2>/dev/null; then
+    echo "WARN: codebase install failed — continuing setup" >&2
+  fi
 fi
 
 if command -v codebase &>/dev/null; then

--- a/.mise/tasks/uninstall
+++ b/.mise/tasks/uninstall
@@ -104,8 +104,8 @@ if [ -d "$TOOL_PATH" ]; then
       if [ -n "$(git -C "$TOOL_PATH" status --porcelain 2>/dev/null | head -1)" ]; then
         repo_dirty=true
       fi
-      if git -C "$TOOL_PATH" rev-parse --verify @{upstream} &>/dev/null; then
-        if [ -n "$(git -C "$TOOL_PATH" log @{upstream}..HEAD --oneline 2>/dev/null | head -1)" ]; then
+      if git -C "$TOOL_PATH" rev-parse --verify '@{upstream}' &>/dev/null; then
+        if [ -n "$(git -C "$TOOL_PATH" log '@{upstream}..HEAD' --oneline 2>/dev/null | head -1)" ]; then
           repo_dirty=true
         fi
       else

--- a/.mise/tasks/update
+++ b/.mise/tasks/update
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Pull latest and refresh shims — optionally for a single package"
 #USAGE arg "[name]" help="Package to update (default: all)"
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/shim.sh"
 
@@ -131,7 +131,9 @@ else
   echo "Updating $COUNT tool(s)..."
   echo ""
   while IFS=$'\t' read -r name repo _ref; do
-    update_one "$name" || true
+    if ! update_one "$name"; then
+      :
+    fi
   done < <(shiv_registry_entries)
 fi
 

--- a/.mise/tasks/which
+++ b/.mise/tasks/which
@@ -1,26 +1,57 @@
 #!/usr/bin/env bash
 #MISE description="Print the install path of a managed tool"
 #USAGE arg "<name>" help="Package name or alias to look up"
-set -eo pipefail
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/shim.sh"
 
 NAME="${usage_name}"
+CALLER_DIR="${CALLER_PWD:-${MISE_ORIGINAL_CWD:-$PWD}}"
+MISE_BIN="${MISE_BIN:-mise}"
 
 shiv_init_registry
 
-# Try direct lookup, then resolve as alias
-PATH_VAL=$(shiv_registry_path "$NAME")
+mise_scoped_package_path() {
+  local name="$1"
+  local caller_dir="$2"
+  local executable package_root
 
-if [ -z "$PATH_VAL" ]; then
-  # Maybe it's an alias
-  RESOLVED=$(shiv_registry_resolve "$NAME")
-  if [ -n "$RESOLVED" ]; then
-    PATH_VAL=$(shiv_registry_path "$RESOLVED")
+  if ! executable=$("$MISE_BIN" -C "$caller_dir" which "$name" 2>/dev/null); then
+    return 1
   fi
-fi
 
-if [ -z "$PATH_VAL" ]; then
+  [ -f "$executable" ] || return 1
+  grep -q "# managed by shiv" "$executable" 2>/dev/null || return 1
+
+  package_root=$(sed -n 's/^REPO="\([^"]*\)".*/\1/p' "$executable" | head -1)
+  [ -n "$package_root" ] || return 1
+
+  echo "$package_root"
+}
+
+global_package_path() {
+  local name="$1"
+  local path_val resolved
+
+  path_val=$(shiv_registry_path "$name")
+
+  if [ -z "$path_val" ]; then
+    resolved=$(shiv_registry_resolve "$name")
+    if [ -n "$resolved" ]; then
+      path_val=$(shiv_registry_path "$resolved")
+    fi
+  fi
+
+  [ -n "$path_val" ] || return 1
+  echo "$path_val"
+}
+
+PATH_VAL=""
+if PATH_VAL=$(mise_scoped_package_path "$NAME" "$CALLER_DIR"); then
+  :
+elif PATH_VAL=$(global_package_path "$NAME"); then
+  :
+else
   echo "shiv: '$NAME' is not a managed tool" >&2
   echo "Run 'shiv list' to see managed tools." >&2
   exit 1

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -43,7 +43,9 @@ if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
 fi
 
 # --- Load chicle with graceful fallback ---
-eval "$(curl -fsSL "$CHICLE_URL" 2>/dev/null)" 2>/dev/null || true
+if ! eval "$(curl -fsSL "$CHICLE_URL" 2>/dev/null)" 2>/dev/null; then
+  :
+fi
 
 # If chicle loaded but tput isn't available (e.g. Alpine), override tput-dependent
 # functions and force non-interactive (chicle_choose needs cursor control)
@@ -245,7 +247,9 @@ else
 fi
 
 MISE_BIN="$(command -v mise)"
-(cd "$SHIV_INSTALL_PATH" && "$MISE_BIN" trust -q 2>/dev/null) || true
+if ! (cd "$SHIV_INSTALL_PATH" && "$MISE_BIN" trust -q 2>/dev/null); then
+  :
+fi
 echo ""
 
 # --- Step 4: Configure registries ---
@@ -344,9 +348,11 @@ fi
 
 if [ "$ALREADY_CONFIGURED" = "0" ] && [ -n "$SHELL_CONFIG" ]; then
   add_shell_config() {
-    echo "" >> "$SHELL_CONFIG"
-    echo "# shiv — managed tool shims" >> "$SHELL_CONFIG"
-    echo "$EVAL_LINE" >> "$SHELL_CONFIG"
+    {
+      echo ""
+      echo "# shiv — managed tool shims"
+      echo "$EVAL_LINE"
+    } >> "$SHELL_CONFIG"
     chicle_log --success "Added to $SHELL_CONFIG"
   }
 

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -39,9 +39,13 @@ shiv_cache_task_map() {
   local cache="$SHIV_CACHE_DIR/tasks/$name"
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/tasks"
-  mise tasks --json --hidden -C "$repo_dir" 2>/dev/null \
+  if ! mise tasks --json --hidden -C "$repo_dir" 2>/dev/null \
     | jq -r '.[].name | gsub(":"; " ")' \
-    > "$tmp" || true
+    > "$tmp"; then
+    rm -f "$tmp"
+    return 0
+  fi
+
   if [ -s "$tmp" ]; then
     mv "$tmp" "$cache"
   else

--- a/lib/format.sh
+++ b/lib/format.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Formatting utilities for shiv output
 
 # strip_ansi — Remove ANSI escape codes from text

--- a/lib/registry.sh
+++ b/lib/registry.sh
@@ -32,7 +32,7 @@ shiv_register() {
   shiv_init_registry
 
   # Check for alias collisions
-  for alias in "${aliases[@]}"; do
+  for alias in ${aliases[@]+"${aliases[@]}"}; do
     # Alias shadows an existing package name?
     if [ -n "$(shiv_registry_path "$alias")" ]; then
       echo "Error: alias '$alias' conflicts with existing package '$alias'" >&2
@@ -49,7 +49,7 @@ shiv_register() {
 
   # Build aliases JSON (null if none)
   local aliases_json="null"
-  if [ ${#aliases[@]} -gt 0 ]; then
+  if [ $# -gt 0 ]; then
     aliases_json=$(printf '%s\n' "${aliases[@]}" | jq -R . | jq -s .)
   fi
 
@@ -98,7 +98,7 @@ shiv_registry_set_aliases() {
   local aliases=("$@")
 
   # Check for alias collisions
-  for alias in "${aliases[@]}"; do
+  for alias in ${aliases[@]+"${aliases[@]}"}; do
     if [ -n "$(shiv_registry_path "$alias")" ]; then
       echo "Error: alias '$alias' conflicts with existing package '$alias'" >&2
       return 1
@@ -112,7 +112,7 @@ shiv_registry_set_aliases() {
   done
 
   local tmp
-  if [ ${#aliases[@]} -eq 0 ]; then
+  if [ $# -eq 0 ]; then
     tmp=$(jq --arg n "$name" '.[$n] |= del(.aliases)' "$SHIV_REGISTRY")
   else
     local aliases_json

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -80,8 +80,12 @@ _shiv_ensure_task_map() {
   fi
   mkdir -p "\$(dirname "\$SHIV_TASK_MAP")"
   local tmp="\$SHIV_TASK_MAP.tmp"
-  mise tasks --json --hidden -C "\$REPO" 2>/dev/null \\
-    | jq -r '.[].name | gsub(":"; " ")' > "\$tmp" 2>/dev/null || true
+  if ! mise tasks --json --hidden -C "\$REPO" 2>/dev/null \\
+    | jq -r '.[].name | gsub(":"; " ")' > "\$tmp" 2>/dev/null; then
+    rm -f "\$tmp"
+    return 0
+  fi
+
   if [ -s "\$tmp" ]; then
     mv "\$tmp" "\$SHIV_TASK_MAP"
   else
@@ -102,17 +106,18 @@ _shiv_handle_tasks() {
 
 SCRIPT
 
-  # Part 2: embed resolver function (quoted heredoc — no variable expansion)
-  cat >> "$SHIV_BIN_DIR/$name" <<'RESOLVE'
+  {
+    # Part 2: embed resolver function (quoted heredoc — no variable expansion)
+    cat <<'RESOLVE'
 # --- embedded from lib/resolve.sh ---
 RESOLVE
-  # Strip the shebang line and inject the function body
-  sed '1{/^#!/d;}' "$REPO_LIB_DIR/resolve.sh" >> "$SHIV_BIN_DIR/$name"
-  echo '# --- end embedded resolver ---' >> "$SHIV_BIN_DIR/$name"
-  echo '' >> "$SHIV_BIN_DIR/$name"
+    # Strip the shebang line and inject the function body
+    sed '1{/^#!/d;}' "$REPO_LIB_DIR/resolve.sh"
+    echo '# --- end embedded resolver ---'
+    echo ''
 
-  # Part 3: main dispatch logic
-  cat >> "$SHIV_BIN_DIR/$name" <<SCRIPT
+    # Part 3: main dispatch logic
+    cat <<SCRIPT
 
 # --- main ---
 _shiv_check_repo
@@ -187,6 +192,7 @@ case "\${1:-}" in
     ;;
 esac
 SCRIPT
+  } >> "$SHIV_BIN_DIR/$name"
 
   chmod +x "$SHIV_BIN_DIR/$name"
 }

--- a/lib/sources.sh
+++ b/lib/sources.sh
@@ -6,8 +6,9 @@ SHIV_SOURCES_DIR="${SHIV_SOURCES_DIR:-$SHIV_CONFIG_DIR/sources}"
 
 # SHIV_SOURCES: comma-delimited list of sources.json files to search.
 # If not set by the user, auto-discover from SHIV_SOURCES_DIR.
+SHIV_SOURCES="${SHIV_SOURCES:-}"
+
 if [ -z "$SHIV_SOURCES" ] && [ -d "$SHIV_SOURCES_DIR" ]; then
-  SHIV_SOURCES=""
   for _sf in "$SHIV_SOURCES_DIR"/*.json; do
     [ -f "$_sf" ] || continue
     SHIV_SOURCES="${SHIV_SOURCES:+$SHIV_SOURCES,}$_sf"
@@ -92,7 +93,7 @@ shiv_detect_ref_type() {
   # Neither a named ref nor a SHA — report the error
   if [ "$ls_exit" -ne 0 ]; then
     echo "Error: failed to query refs for $gh_repo" >&2
-    echo "$ls_output" | sed 's/^/  /' >&2
+    printf '%s\n' "$ls_output" | sed 's/^/  /' >&2
   else
     echo "Error: ref '$ref' not found in $gh_repo" >&2
   fi

--- a/mise.toml
+++ b/mise.toml
@@ -1,14 +1,19 @@
 [settings]
 quiet = true
 task_output = "interleave"
+experimental = true
+
+[plugins]
+shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
+"shiv:codebase" = "0.2.0"
 bats = "1.13.0"
 gum = "0.17.0"
 jsonschema = "14.14.2"
 
 [_.codebase]
-lint = ["mise-settings", "gum-table"]
+lint = ["mise-settings", "bats-test-helper", "bats-test-task", "mcr-scope", "or-true", "shellcheck", "gum-table"]
 
 [_.codebase.scope]
 gum-table = ".mise/tasks"

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -91,7 +91,9 @@ create_local_package() {
   git -C "$pkg_dir" commit -q -m "init"
 
   # Remove origin so there's no remote
-  git -C "$pkg_dir" remote remove origin 2>/dev/null || true
+  if ! git -C "$pkg_dir" remote remove origin 2>/dev/null; then
+    :
+  fi
 
   shiv_register "$name" "$pkg_dir"
 }

--- a/test/which.bats
+++ b/test/which.bats
@@ -63,6 +63,17 @@ SHIM
   chmod +x "$executable"
 }
 
+create_plain_executable() {
+  local executable="$1"
+
+  mkdir -p "$(dirname "$executable")"
+  cat > "$executable" <<'PLAIN'
+#!/usr/bin/env bash
+echo plain executable
+PLAIN
+  chmod +x "$executable"
+}
+
 create_global_package() {
   local name="$1"
   local repo_dir="$2"
@@ -126,6 +137,38 @@ run_which_from() {
   run run_which_from "$caller_dir" "charlie"
   [ "$status" -eq 0 ]
   [ "$output" = "$global_repo" ]
+}
+
+@test "which: falls back to global registry when mise resolves a non-shiv executable" {
+  local caller_dir="$TEST_HOME/project"
+  local global_repo="$SHIV_PACKAGES_DIR/charlie"
+  local non_shiv_executable="$TEST_HOME/.local/bin/charlie"
+
+  create_global_package "charlie" "$global_repo"
+  create_plain_executable "$non_shiv_executable"
+
+  export FAKE_MISE_CWD="$caller_dir"
+  export FAKE_MISE_NAME="charlie"
+  export FAKE_MISE_PATH="$non_shiv_executable"
+
+  run run_which_from "$caller_dir" "charlie"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$global_repo" ]
+}
+
+@test "which: rejects non-shiv mise executable when no global fallback exists" {
+  local caller_dir="$TEST_HOME/project"
+  local non_shiv_executable="$TEST_HOME/.local/bin/echo-tool"
+
+  create_plain_executable "$non_shiv_executable"
+
+  export FAKE_MISE_CWD="$caller_dir"
+  export FAKE_MISE_NAME="echo-tool"
+  export FAKE_MISE_PATH="$non_shiv_executable"
+
+  run run_which_from "$caller_dir" "echo-tool"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"shiv: 'echo-tool' is not a managed tool"* ]]
 }
 
 @test "which: global alias fallback still resolves" {

--- a/test/which.bats
+++ b/test/which.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# shiv which test suite
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+load helpers
+
+setup() {
+  source "$REPO_DIR/lib/shim.sh"
+
+  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  mkdir -p "$TEST_HOME"
+
+  export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
+  export SHIV_DATA_DIR="$TEST_HOME/.local/share/shiv"
+  export SHIV_PACKAGES_DIR="$SHIV_DATA_DIR/packages"
+  export SHIV_CONFIG_DIR="$TEST_HOME/.config/shiv"
+  export SHIV_CACHE_DIR="$TEST_HOME/.cache/shiv"
+  export SHIV_REGISTRY="$SHIV_CONFIG_DIR/registry.json"
+
+  mkdir -p "$SHIV_BIN_DIR"
+  shiv_init_registry
+  setup_shiv_on_path
+
+  export MISE_BIN="$BATS_TEST_TMPDIR/fake-mise"
+  create_fake_mise "$MISE_BIN"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+create_fake_mise() {
+  local fake_mise="$1"
+
+  cat > "$fake_mise" <<'MOCK'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-C" ] && [ "${3:-}" = "which" ]; then
+  if [ "${2:-}" = "${FAKE_MISE_CWD:-}" ] && [ "${4:-}" = "${FAKE_MISE_NAME:-}" ]; then
+    printf '%s\n' "$FAKE_MISE_PATH"
+    exit 0
+  fi
+  echo "mise ERROR ${4:-} is not active" >&2
+  exit 1
+fi
+
+echo "unexpected fake mise invocation: $*" >&2
+exit 127
+MOCK
+  chmod +x "$fake_mise"
+}
+
+create_managed_mise_shim() {
+  local repo_dir="$1"
+  local executable="$2"
+
+  mkdir -p "$repo_dir" "$(dirname "$executable")"
+  cat > "$executable" <<SHIM
+#!/usr/bin/env bash
+# managed by shiv
+REPO="$repo_dir"
+exec mise -C "\$REPO" run -q "\$@"
+SHIM
+  chmod +x "$executable"
+}
+
+create_global_package() {
+  local name="$1"
+  local repo_dir="$2"
+  shift 2
+
+  mkdir -p "$repo_dir"
+  shiv_register "$name" "$repo_dir" "$@"
+}
+
+run_which_from() {
+  local caller_dir="$1"
+  local name="$2"
+
+  mkdir -p "$caller_dir"
+  cd "$caller_dir"
+  shiv which "$name" 2>&1
+}
+
+@test "which: current mise-scoped shiv package wins over global registry" {
+  local caller_dir="$TEST_HOME/project"
+  local global_repo="$SHIV_PACKAGES_DIR/alpha-global"
+  local mise_repo="$TEST_HOME/.local/share/mise/installs/shiv-alpha/1.0.0/packages/alpha"
+  local mise_executable="$TEST_HOME/.local/share/mise/installs/shiv-alpha/1.0.0/bin/alpha"
+
+  create_global_package "alpha" "$global_repo"
+  create_managed_mise_shim "$mise_repo" "$mise_executable"
+
+  export FAKE_MISE_CWD="$caller_dir"
+  export FAKE_MISE_NAME="alpha"
+  export FAKE_MISE_PATH="$mise_executable"
+
+  run run_which_from "$caller_dir" "alpha"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$mise_repo" ]
+}
+
+@test "which: current mise-scoped shiv package resolves without global registry entry" {
+  local caller_dir="$TEST_HOME/project"
+  local mise_repo="$TEST_HOME/.local/share/mise/installs/shiv-bravo/2.0.0/packages/bravo"
+  local mise_executable="$TEST_HOME/.local/share/mise/installs/shiv-bravo/2.0.0/bin/bravo"
+
+  create_managed_mise_shim "$mise_repo" "$mise_executable"
+
+  export FAKE_MISE_CWD="$caller_dir"
+  export FAKE_MISE_NAME="bravo"
+  export FAKE_MISE_PATH="$mise_executable"
+
+  run run_which_from "$caller_dir" "bravo"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$mise_repo" ]
+}
+
+@test "which: falls back to global registry when mise has no active shiv package" {
+  local caller_dir="$TEST_HOME/project"
+  local global_repo="$SHIV_PACKAGES_DIR/charlie"
+
+  create_global_package "charlie" "$global_repo"
+
+  unset FAKE_MISE_CWD FAKE_MISE_NAME FAKE_MISE_PATH
+
+  run run_which_from "$caller_dir" "charlie"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$global_repo" ]
+}
+
+@test "which: global alias fallback still resolves" {
+  local caller_dir="$TEST_HOME/project"
+  local global_repo="$SHIV_PACKAGES_DIR/delta"
+
+  create_global_package "delta" "$global_repo" "d"
+
+  unset FAKE_MISE_CWD FAKE_MISE_NAME FAKE_MISE_PATH
+
+  run run_which_from "$caller_dir" "d"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$global_repo" ]
+}


### PR DESCRIPTION
## Summary
- make `shiv which <name>` prefer the active mise-scoped shiv install from the caller cwd
- preserve global registry and alias fallback when mise has no active shiv-managed executable
- add `which` regression coverage for mise-vs-global precedence
- wire shiv into codebase linting via vfox-shiv plugin + `shiv:codebase@0.2.0`
- remove existing `|| true`, shellcheck, and bash 3.2 `set -u` violations caught while enabling those rules

Fixes #100.

Follow-up filed: #104 for a coordinated `CALLER_PWD` → `SHIV_CALLER_PWD` migration.

## Tests
- `CALLER_PWD=/Users/rikonor/agents/junior/shiv codebase lint:mise-settings /Users/rikonor/agents/junior/shiv`
- `CALLER_PWD=/Users/rikonor/agents/junior/shiv codebase lint:bats-test-helper /Users/rikonor/agents/junior/shiv`
- `CALLER_PWD=/Users/rikonor/agents/junior/shiv codebase lint:bats-test-task /Users/rikonor/agents/junior/shiv`
- `CALLER_PWD=/Users/rikonor/agents/junior/shiv codebase lint:mcr-scope /Users/rikonor/agents/junior/shiv`
- `CALLER_PWD=/Users/rikonor/agents/junior/shiv codebase lint:or-true /Users/rikonor/agents/junior/shiv`
- `CALLER_PWD=/Users/rikonor/agents/junior/shiv codebase lint:shellcheck /Users/rikonor/agents/junior/shiv`
- `CALLER_PWD=/Users/rikonor/agents/junior/shiv codebase lint:gum-table /Users/rikonor/agents/junior/shiv`
- `mise run test`
- CI: all checks passing