### PR TITLE
fix: normalize shiv shell PATH precedence

### DIFF
--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -207,27 +207,76 @@ shiv_create_alias_symlinks() {
   done
 }
 
+# Quote a value for POSIX-ish shell eval output.
+shiv_shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+# Remove exact PATH entries from a colon-separated path string.
+shiv_path_remove_entries() {
+  local path_value="$1"
+  shift
+
+  local result=""
+  local result_set="false"
+  local entry=""
+  local remove=""
+  local remainder="$path_value:"
+  local skip="false"
+
+  while [ -n "$remainder" ]; do
+    entry="${remainder%%:*}"
+    remainder="${remainder#*:}"
+
+    skip="false"
+    for remove in "$@"; do
+      if [ "$entry" = "$remove" ]; then
+        skip="true"
+        break
+      fi
+    done
+
+    if [ "$skip" = "false" ]; then
+      if [ "$result_set" = "true" ]; then
+        result="$result:$entry"
+      else
+        result="$entry"
+        result_set="true"
+      fi
+    fi
+  done
+
+  printf '%s\n' "$result"
+}
+
 # Emit shell export statements to put shiv's bin dir and mise's shims dir on PATH.
 # Designed to be eval'd: `eval "$(shiv_emit_path_exports)"`
-# Mise shims are emitted after SHIV_BIN_DIR so they end up first on PATH —
-# when a directory's mise.toml pins a version, the mise shim wins over the
-# global shiv shim.
+# Mise shims must precede SHIV_BIN_DIR so repo-scoped mise pins win over the
+# global shiv shim. Normalize order and de-duplicate, instead of only checking
+# that both directories are present somewhere on PATH.
 shiv_emit_path_exports() {
-  # Ensure SHIV_BIN_DIR (~/.local/bin) is on PATH
-  case ":$PATH:" in
-    *":$SHIV_BIN_DIR:"*) ;;
-    *) echo "export PATH=\"$SHIV_BIN_DIR:\$PATH\"" ;;
-  esac
-
-  # Ensure mise shims are on PATH so shiv packages installed via vfox-shiv
-  # resolve correctly in non-interactive shells (agent sessions, scripts, etc.).
+  local current_path="${PATH:-}"
   local mise_shims_dir="${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims"
+  local path_rest=""
+  local normalized_path=""
+
   if [ -d "$mise_shims_dir" ]; then
-    case ":$PATH:" in
-      *":$mise_shims_dir:"*) ;;
-      *) echo "export PATH=\"$mise_shims_dir:\$PATH\"" ;;
-    esac
+    path_rest=$(shiv_path_remove_entries "$current_path" "$mise_shims_dir" "$SHIV_BIN_DIR")
+    normalized_path="$mise_shims_dir:$SHIV_BIN_DIR"
+  else
+    path_rest=$(shiv_path_remove_entries "$current_path" "$SHIV_BIN_DIR")
+    normalized_path="$SHIV_BIN_DIR"
   fi
+
+  if [ -n "$path_rest" ]; then
+    normalized_path="$normalized_path:$path_rest"
+  fi
+
+  [ "$normalized_path" = "$current_path" ] && return 0
+
+  printf 'export PATH=%s\n' "$(shiv_shell_quote "$normalized_path")"
 }
 
 # Remove alias symlinks for a package (only if they point to the expected target)

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -35,48 +35,22 @@ teardown() {
 
   run shiv_emit_path_exports
   [ "$status" -eq 0 ]
-  [[ "$output" == *"export PATH=\"$SHIV_BIN_DIR:"* ]]
+  [[ "$output" == *"export PATH='$SHIV_BIN_DIR:"* ]]
 }
 
-@test "shell: skips SHIV_BIN_DIR when already on PATH" {
+@test "shell: skips SHIV_BIN_DIR when already first on PATH" {
   export PATH="$SHIV_BIN_DIR:$PATH"
 
   run shiv_emit_path_exports
   [ "$status" -eq 0 ]
-  [[ "$output" != *"export PATH=\"$SHIV_BIN_DIR:"* ]]
+  [ -z "$output" ]
 }
 
 # ============================================================================
 # Mise shims on PATH
 # ============================================================================
 
-@test "shell: adds mise shims dir to PATH when present on disk" {
-  local shims_dir="$TEST_HOME/.local/share/mise/shims"
-  mkdir -p "$shims_dir"
-  export PATH="${PATH//$shims_dir:/}"
-
-  run shiv_emit_path_exports
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
-}
-
-@test "shell: skips mise shims dir when already on PATH" {
-  local shims_dir="$TEST_HOME/.local/share/mise/shims"
-  mkdir -p "$shims_dir"
-  export PATH="$shims_dir:$PATH"
-
-  run shiv_emit_path_exports
-  [ "$status" -eq 0 ]
-  [[ "$output" != *"export PATH=\"$shims_dir:"* ]]
-}
-
-@test "shell: skips mise shims dir when it does not exist" {
-  run shiv_emit_path_exports
-  [ "$status" -eq 0 ]
-  [[ "$output" != *"mise/shims"* ]]
-}
-
-@test "shell: mise shims emitted after SHIV_BIN_DIR (ends up first on PATH)" {
+@test "shell: adds mise shims dir before SHIV_BIN_DIR when present on disk" {
   local shims_dir="$TEST_HOME/.local/share/mise/shims"
   mkdir -p "$shims_dir"
   export PATH="${PATH//$SHIV_BIN_DIR:/}"
@@ -84,16 +58,35 @@ teardown() {
 
   run shiv_emit_path_exports
   [ "$status" -eq 0 ]
+  [[ "$output" == *"export PATH='$shims_dir:$SHIV_BIN_DIR:"* ]]
+}
 
-  [[ "$output" == *"$SHIV_BIN_DIR"* ]]
-  [[ "$output" == *"$shims_dir"* ]]
+@test "shell: skips output when mise shims and SHIV_BIN_DIR are already ordered" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+  mkdir -p "$shims_dir"
+  export PATH="$shims_dir:$SHIV_BIN_DIR:$PATH"
 
-  # SHIV_BIN_DIR should appear before mise shims in output
-  # (since both prepend, the later one ends up first on PATH)
-  local bin_line shims_line
-  bin_line=$(echo "$output" | grep -n "$SHIV_BIN_DIR" | head -1 | cut -d: -f1)
-  shims_line=$(echo "$output" | grep -n "mise/shims" | head -1 | cut -d: -f1)
-  [ "$bin_line" -lt "$shims_line" ]
+  run shiv_emit_path_exports
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "shell: skips mise shims dir when it does not exist" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+
+  run shiv_emit_path_exports
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"$shims_dir"* ]]
+}
+
+@test "shell: corrects wrong-order PATH so mise shims precede SHIV_BIN_DIR" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+  mkdir -p "$shims_dir"
+  export PATH="$SHIV_BIN_DIR:$shims_dir:$PATH"
+
+  run shiv_emit_path_exports
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"export PATH='$shims_dir:$SHIV_BIN_DIR:"* ]]
 }
 
 @test "shell: respects MISE_DATA_DIR for shims path" {
@@ -104,7 +97,7 @@ teardown() {
 
   run shiv_emit_path_exports
   [ "$status" -eq 0 ]
-  [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
+  [[ "$output" == *"export PATH='$shims_dir:$SHIV_BIN_DIR:"* ]]
 }
 
 @test "shell: respects XDG_DATA_HOME for shims path" {
@@ -116,7 +109,7 @@ teardown() {
 
   run shiv_emit_path_exports
   [ "$status" -eq 0 ]
-  [[ "$output" == *"export PATH=\"$shims_dir:"* ]]
+  [[ "$output" == *"export PATH='$shims_dir:$SHIV_BIN_DIR:"* ]]
 }
 
 # ============================================================================
@@ -133,7 +126,34 @@ teardown() {
 
   # mise shims should come before SHIV_BIN_DIR
   local shims_pos bin_pos
-  shims_pos=$(echo "$PATH" | tr ':' '\n' | grep -n "mise/shims" | head -1 | cut -d: -f1)
-  bin_pos=$(echo "$PATH" | tr ':' '\n' | grep -n "$SHIV_BIN_DIR" | head -1 | cut -d: -f1)
+  shims_pos=$(echo "$PATH" | tr ':' '\n' | grep -nF "$shims_dir" | head -1 | cut -d: -f1)
+  bin_pos=$(echo "$PATH" | tr ':' '\n' | grep -nF "$SHIV_BIN_DIR" | head -1 | cut -d: -f1)
   [ "$shims_pos" -lt "$bin_pos" ]
+}
+
+@test "shell: eval output corrects existing wrong-order PATH" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+  mkdir -p "$shims_dir"
+  export PATH="$SHIV_BIN_DIR:$shims_dir:$PATH"
+
+  eval "$(shiv_emit_path_exports)"
+
+  local shims_pos bin_pos
+  shims_pos=$(echo "$PATH" | tr ':' '\n' | grep -nF "$shims_dir" | head -1 | cut -d: -f1)
+  bin_pos=$(echo "$PATH" | tr ':' '\n' | grep -nF "$SHIV_BIN_DIR" | head -1 | cut -d: -f1)
+  [ "$shims_pos" -lt "$bin_pos" ]
+}
+
+@test "shell: eval output de-duplicates managed PATH entries" {
+  local shims_dir="$TEST_HOME/.local/share/mise/shims"
+  mkdir -p "$shims_dir"
+  export PATH="$SHIV_BIN_DIR:$shims_dir:$SHIV_BIN_DIR:$PATH:$shims_dir"
+
+  eval "$(shiv_emit_path_exports)"
+
+  local shims_count bin_count
+  shims_count=$(echo "$PATH" | tr ':' '\n' | grep -cF "$shims_dir")
+  bin_count=$(echo "$PATH" | tr ':' '\n' | grep -cF "$SHIV_BIN_DIR")
+  [ "$shims_count" -eq 1 ]
+  [ "$bin_count" -eq 1 ]
 }


### PR DESCRIPTION
## Summary

- Normalize `shiv shell` PATH output instead of only checking whether shiv/mise dirs are present.
- Ensure mise shims precede `SHIV_BIN_DIR` so repo-scoped `shiv:<pkg>` pins win over global shiv shims.
- De-duplicate managed PATH entries while preserving the rest of PATH.
- Add regression coverage for wrong-order and duplicate PATH entries.

Closes #106.

## Verification

```bash
mise run test
mise run test completions
CALLER_PWD="$PWD" codebase lint:shellcheck "$PWD"
CALLER_PWD="$PWD" codebase lint:mise-settings "$PWD"
CALLER_PWD="$PWD" codebase lint:bats-test-helper "$PWD"
CALLER_PWD="$PWD" codebase lint:bats-test-task "$PWD"
CALLER_PWD="$PWD" codebase lint:mcr-scope "$PWD"
CALLER_PWD="$PWD" codebase lint:or-true "$PWD"
CALLER_PWD="$PWD" codebase lint:gum-table "$PWD"
```
