### PR TITLE
fix: run dependency setup for local path installs

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -112,16 +112,18 @@ else
     esac
   fi
 
-  # Set up dependencies
+fi
+
+if [ -f "$TOOL_PATH/mise.toml" ]; then
+  # Set up dependencies after resolving TOOL_PATH so both package installs and
+  # local path installs trust/install the tool repo before shim creation.
   printf -v escaped_path '%q' "$TOOL_PATH"
   dep_output=$(gum spin --title "  Setting up dependencies..." -- bash -c "cd $escaped_path && mise trust -q 2>&1 && mise install -q 2>&1") || {
     echo "  ✗ Failed to install dependencies for $NAME" >&2
     echo "$dep_output" | strip_ansi | sed 's/^/    /' >&2
     exit 1
   }
-fi
-
-if [ ! -f "$TOOL_PATH/mise.toml" ]; then
+else
   echo "  ⚠ No mise.toml found at $TOOL_PATH"
 fi
 

--- a/test/install.bats
+++ b/test/install.bats
@@ -70,6 +70,24 @@ run_install() {
   "${cmd[@]}" 2>&1
 }
 
+# Helper: record dependency-setup calls while delegating the outer shiv task
+# invocation to the real mise binary.
+record_dependency_mise_calls() {
+  local real_mise
+  real_mise="$(command -v mise)"
+  export MISE_CALL_LOG="$TEST_HOME/mise-calls.log"
+
+  cat > "$BATS_TEST_TMPDIR/mock-bin/mise" <<MOCK
+#!/usr/bin/env bash
+if [ "\${1:-}" = "-C" ] && [ "\${2:-}" = "$REPO_DIR" ]; then
+  exec "$real_mise" "\$@"
+fi
+printf '%s\t%s\n' "\$PWD" "\$*" >> "$MISE_CALL_LOG"
+exit 0
+MOCK
+  chmod +x "$BATS_TEST_TMPDIR/mock-bin/mise"
+}
+
 # ============================================================================
 # Local path install
 # ============================================================================
@@ -100,6 +118,18 @@ run_install() {
 
   run_install "myapp" "$repo_dir"
   [ -n "$(shiv_registry_path "myapp")" ]
+}
+
+@test "install: local path install runs mise trust and install" {
+  local repo_dir
+  repo_dir=$(create_local_repo "myapp")
+  record_dependency_mise_calls
+
+  run run_install "myapp" "$repo_dir"
+  [ "$status" -eq 0 ]
+
+  grep -F "$(printf '%s\ttrust -q' "$repo_dir")" "$MISE_CALL_LOG"
+  grep -F "$(printf '%s\tinstall -q' "$repo_dir")" "$MISE_CALL_LOG"
 }
 
 @test "install: shows branch in summary card" {


### PR DESCRIPTION
## Summary

Fixes KnickKnackLabs/shiv#39.

`shiv install <name> <local-path>` now runs the same `mise trust` / `mise install` dependency setup as package-index installs after resolving `TOOL_PATH`.

Preserves existing behavior for directories without `mise.toml`: warn and continue.

## Verification

- `mise run test install`
- `mise run test`
- configured codebase lints on absolute repo path:
  - `codebase lint:mise-settings /Users/rikonor/agents/rho/shiv`
  - `codebase lint:bats-test-helper /Users/rikonor/agents/rho/shiv`
  - `codebase lint:bats-test-task /Users/rikonor/agents/rho/shiv`
  - `codebase lint:mcr-scope /Users/rikonor/agents/rho/shiv`
  - `codebase lint:or-true /Users/rikonor/agents/rho/shiv`
  - `codebase lint:shellcheck /Users/rikonor/agents/rho/shiv`
  - `codebase lint:gum-table /Users/rikonor/agents/rho/shiv`

Note: `codebase lint:mise-settings .` incorrectly failed on `.` while the absolute path passed and an `origin/main` archive passed; using the absolute target avoids that codebase path-resolution quirk.
