### PR TITLE
test: use per-test BATS temp dirs

### DIFF
--- a/test/completions.bats
+++ b/test/completions.bats
@@ -7,7 +7,7 @@ setup() {
   source "$REPO_DIR/lib/shim.sh"
 
   # Use a temporary home for isolation
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   # Override shiv paths to use test home
@@ -24,9 +24,6 @@ setup() {
   shiv_register "shiv" "$REPO_DIR"
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # ============================================================================
 # Cache generation
@@ -150,8 +147,8 @@ teardown() {
     skip "zsh not found"
   fi
   shiv_cache_tasks "shiv" "$REPO_DIR"
-  mise -C "$REPO_DIR" run -q completions:zsh > "$BATS_TMPDIR/comp.zsh"
-  run zsh -n "$BATS_TMPDIR/comp.zsh"
+  mise -C "$REPO_DIR" run -q completions:zsh > "$BATS_TEST_TMPDIR/comp.zsh"
+  run zsh -n "$BATS_TEST_TMPDIR/comp.zsh"
   [ "$status" -eq 0 ]
 }
 
@@ -178,8 +175,8 @@ teardown() {
     skip "fish not found"
   fi
   shiv_cache_tasks "shiv" "$REPO_DIR"
-  mise -C "$REPO_DIR" run -q completions:fish > "$BATS_TMPDIR/comp.fish"
-  run fish -n "$BATS_TMPDIR/comp.fish"
+  mise -C "$REPO_DIR" run -q completions:fish > "$BATS_TEST_TMPDIR/comp.fish"
+  run fish -n "$BATS_TEST_TMPDIR/comp.fish"
   [ "$status" -eq 0 ]
 }
 

--- a/test/doctor.bats
+++ b/test/doctor.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -22,9 +22,6 @@ setup() {
   setup_shiv_on_path
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # Helper: create a minimal installed package (repo, shim, registry)
 create_installed_package() {
@@ -123,8 +120,9 @@ run_doctor() {
 # ============================================================================
 
 @test "doctor: missing repo shows ✗" {
-  shiv_register "gone" "/tmp/nonexistent-repo-$$"
-  shiv_create_shim "gone" "/tmp/nonexistent-repo-$$"
+  local missing_repo="$TEST_HOME/nonexistent-repo"
+  shiv_register "gone" "$missing_repo"
+  shiv_create_shim "gone" "$missing_repo"
 
   run run_doctor
   [ "$status" -ne 0 ]

--- a/test/install.bats
+++ b/test/install.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -25,9 +25,6 @@ setup() {
   export SHIV_SKIP_CACHE=1
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # Helper: create a local repo to install from (simulates local path install)
 create_local_repo() {

--- a/test/list.bats
+++ b/test/list.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -21,9 +21,6 @@ setup() {
   setup_shiv_on_path
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # Helper: create a git repo with a specific commit date
 # Usage: create_test_repo <name> [iso_date] [branch]

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -25,9 +25,6 @@ setup() {
   setup_shiv_on_path
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # Helper: create a bare remote repo with tags
 # Usage: create_remote <name> [tag1 tag2 ...]
@@ -324,7 +321,7 @@ create_local_package() {
 }
 
 @test "outdated: missing repo shows repo missing" {
-  shiv_register "ghost" "/tmp/nonexistent-shiv-test-$$"
+  shiv_register "ghost" "$TEST_HOME/nonexistent-repo"
 
   run shiv outdated
   [ "$status" -eq 0 ]

--- a/test/registry.bats
+++ b/test/registry.bats
@@ -6,7 +6,7 @@ REPO_DIR="$BATS_TEST_DIRNAME/.."
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -20,9 +20,6 @@ setup() {
   shiv_init_registry
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # ============================================================================
 # Registry format

--- a/test/resolve.bats
+++ b/test/resolve.bats
@@ -9,7 +9,7 @@ setup() {
   source "$REPO_DIR/lib/shim.sh"
 
   # Use a temporary home for isolation
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   # Override shiv paths to use test home
@@ -26,9 +26,6 @@ setup() {
   shiv_register "shiv" "$REPO_DIR"
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # ============================================================================
 # Task map cache generation

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export HOME="$TEST_HOME"
@@ -22,9 +22,6 @@ setup() {
   shiv_init_registry
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # ============================================================================
 # SHIV_BIN_DIR on PATH

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -24,9 +24,6 @@ setup() {
   export SHIV_SKIP_CACHE=1
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # Helper: create a repo with a task that echoes CALLER_PWD
 create_caller_repo() {

--- a/test/uninstall.bats
+++ b/test/uninstall.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -24,9 +24,6 @@ setup() {
   export SHIV_SKIP_CACHE=1
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # Helper: create a minimal installed package (repo, shim, registry, cache)
 create_installed_package() {
@@ -211,8 +208,9 @@ MOCK
 
 @test "uninstall: summary card shows not found for missing path" {
   # Register a package pointing to a nonexistent path
-  shiv_register "gone" "/tmp/nonexistent-repo-$$"
-  shiv_create_shim "gone" "/tmp/nonexistent-repo-$$"
+  local missing_repo="$TEST_HOME/nonexistent-repo"
+  shiv_register "gone" "$missing_repo"
+  shiv_create_shim "gone" "$missing_repo"
 
   run run_uninstall "gone" "true"
   [ "$status" -eq 0 ]

--- a/test/update.bats
+++ b/test/update.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -22,9 +22,6 @@ setup() {
   setup_shiv_on_path
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 # Helper: create a git repo with a remote (bare repo as origin)
 create_test_repo_with_remote() {
@@ -53,7 +50,7 @@ create_test_repo_with_remote() {
 push_remote_commit() {
   local name="$1"
   local bare_dir="$TEST_HOME/remotes/$name.git"
-  local tmp_dir="$TEST_HOME/tmp-clone-$$"
+  local tmp_dir="$TEST_HOME/tmp-clone"
 
   git clone -q "$bare_dir" "$tmp_dir"
   git -C "$tmp_dir" config user.email "test@test.com"
@@ -101,7 +98,7 @@ extract_column() {
 }
 
 @test "update: missing repo directory shows error" {
-  shiv_register "gone" "/tmp/nonexistent-repo-$$"
+  shiv_register "gone" "$TEST_HOME/nonexistent-repo"
   run run_update "gone"
   [ "$status" -ne 0 ]
   echo "$output" | grep -q "repo not found"

--- a/test/which.bats
+++ b/test/which.bats
@@ -7,7 +7,7 @@ load helpers
 setup() {
   source "$REPO_DIR/lib/shim.sh"
 
-  export TEST_HOME="$BATS_TMPDIR/shiv-test-$$"
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
   mkdir -p "$TEST_HOME"
 
   export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
@@ -25,9 +25,6 @@ setup() {
   create_fake_mise "$MISE_BIN"
 }
 
-teardown() {
-  rm -rf "$TEST_HOME"
-}
 
 create_fake_mise() {
   local fake_mise="$1"


### PR DESCRIPTION
## Summary

Fixes KnickKnackLabs/shiv#34.

Moves shiv's BATS scratch home from `$BATS_TMPDIR/shiv-test-$$` to `$BATS_TEST_TMPDIR/shiv`, so each test gets an isolated directory managed by BATS. While the issue named `registry.bats` and `completions.bats`, the same pattern had spread across the suite, so this updates all affected test files consistently.

Also removes manual `rm -rf "$TEST_HOME"` teardowns and replaces remaining test-only `$$` temp paths with per-test paths under `$TEST_HOME`.

## Verification

- `mise run test registry completions`
- `mise run test`
- configured codebase lints:
  - `codebase lint:mise-settings /Users/rikonor/agents/rho/shiv`
  - `codebase lint:bats-test-helper /Users/rikonor/agents/rho/shiv`
  - `codebase lint:bats-test-task /Users/rikonor/agents/rho/shiv`
  - `codebase lint:mcr-scope /Users/rikonor/agents/rho/shiv`
  - `codebase lint:or-true /Users/rikonor/agents/rho/shiv`
  - `codebase lint:shellcheck /Users/rikonor/agents/rho/shiv`
  - `codebase lint:gum-table /Users/rikonor/agents/rho/shiv`
