### PR TITLE
Emit package-specific caller cwd vars

### DIFF
--- a/.mise/tasks/which
+++ b/.mise/tasks/which
@@ -6,7 +6,7 @@ set -euo pipefail
 source "$MISE_CONFIG_ROOT/lib/shim.sh"
 
 NAME="${usage_name}"
-CALLER_DIR="${CALLER_PWD:-${MISE_ORIGINAL_CWD:-$PWD}}"
+CALLER_DIR="${SHIV_CALLER_PWD:-${CALLER_PWD:-${MISE_ORIGINAL_CWD:-$PWD}}}"
 MISE_BIN="${MISE_BIN:-mise}"
 
 shiv_init_registry

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When you run `shiv install foo`, shiv:
 4. Generates a shim at `~/.local/bin/foo`
 5. Registers the package in `~/.config/shiv/registry.json`
 
-The shim is a bash script that forwards commands to `mise -C <repo> run`. It exports `CALLER_PWD` so tools know where you invoked them, translates space-separated arguments to colon-joined task names (`agent message` → `agent:message`), and provides tab completions for all available tasks.
+The shim is a bash script that forwards commands to `mise -C <repo> run`. It exports a package-specific caller variable (for example, `SHIMMER_CALLER_PWD` for `shimmer`) so tools know where you invoked them, translates space-separated arguments to colon-joined task names (`agent message` → `agent:message`), and provides tab completions for all available tasks.
 
 ## Install
 

--- a/README.tsx
+++ b/README.tsx
@@ -96,7 +96,7 @@ shiv doctor`}</CodeBlock>
       <Paragraph>
         The shim is a bash script that forwards commands to{" "}
         <Code>{"mise -C <repo> run"}</Code>. It exports{" "}
-        <Code>CALLER_PWD</Code> so tools know where you invoked them,
+        a package-specific caller variable (for example, <Code>SHIMMER_CALLER_PWD</Code>) so tools know where you invoked them,
         translates space-separated arguments to colon-joined task names
         (<Code>agent message</Code> → <Code>agent:message</Code>),
         and provides tab completions for all available tasks.

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -16,9 +16,22 @@ SHIV_DATA_DIR="${SHIV_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/shiv}"
 SHIV_PACKAGES_DIR="${SHIV_PACKAGES_DIR:-$SHIV_DATA_DIR/packages}"
 
 # Create a shim for a tool
+shiv_caller_pwd_var_name() {
+  local name="$1"
+  local var
+  var=$(printf '%s' "$name" | tr '[:lower:]' '[:upper:]' | sed 's/[^A-Z0-9_]/_/g')
+  case "$var" in
+    [A-Z_]*) ;;
+    *) var="_$var" ;;
+  esac
+  printf '%s_CALLER_PWD\n' "$var"
+}
+
 shiv_create_shim() {
   local name="$1" repo_dir="$2"
   local default_task=""
+  local caller_pwd_var
+  caller_pwd_var=$(shiv_caller_pwd_var_name "$name")
 
   # At install time, detect a default task for single-command tools.
   # Checks .mise/tasks/<name> first, then .mise/tasks/_default.
@@ -121,7 +134,7 @@ RESOLVE
 
 # --- main ---
 _shiv_check_repo
-export CALLER_PWD="\$PWD"
+export ${caller_pwd_var}="\$PWD"
 _shiv_check_cwd "\$@"
 
 case "\${1:-}" in

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -8,7 +8,7 @@ setup_shiv_on_path() {
   mkdir -p "$mock_bin"
   cat > "$mock_bin/shiv" <<MOCK
 #!/usr/bin/env bash
-export CALLER_PWD="\$PWD"
+export SHIV_CALLER_PWD="\$PWD"
 exec mise -C "$REPO_DIR" run -q "\$@"
 MOCK
   chmod +x "$mock_bin/shiv"

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# Shim runtime behavior tests — CALLER_PWD propagation, default task, etc.
+# Shim runtime behavior tests — <PACKAGE>_CALLER_PWD propagation, default task, etc.
 
 REPO_DIR="$BATS_TEST_DIRNAME/.."
 load helpers
@@ -25,7 +25,7 @@ setup() {
 }
 
 
-# Helper: create a repo with a task that echoes CALLER_PWD
+# Helper: create a repo with a task that echoes MYAPP_CALLER_PWD
 create_caller_repo() {
   local name="$1"
   local repo_dir="$TEST_HOME/repos/$name"
@@ -39,8 +39,8 @@ create_caller_repo() {
 
   cat > "$repo_dir/.mise/tasks/show-caller" <<'TASK'
 #!/usr/bin/env bash
-#MISE description="Print CALLER_PWD"
-echo "$CALLER_PWD"
+#MISE description="Print MYAPP_CALLER_PWD"
+echo "$MYAPP_CALLER_PWD"
 TASK
   chmod +x "$repo_dir/.mise/tasks/show-caller"
 
@@ -49,24 +49,25 @@ TASK
   mise trust "$repo_dir/mise.toml" 2>/dev/null
 
   mkdir -p "$SHIV_CACHE_DIR/completions"
-  printf 'show-caller\tPrint CALLER_PWD\n' > "$SHIV_CACHE_DIR/completions/$name.cache"
+  printf 'show-caller\tPrint MYAPP_CALLER_PWD\n' > "$SHIV_CACHE_DIR/completions/$name.cache"
 
   echo "$repo_dir"
 }
 
 # ============================================================================
-# CALLER_PWD propagation
+# <PACKAGE>_CALLER_PWD propagation
 # ============================================================================
 
-@test "shim: template uses unconditional CALLER_PWD assignment" {
+@test "shim: template uses unconditional package-specific caller assignment" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
 
-  grep -q 'CALLER_PWD="$PWD"' "$SHIV_BIN_DIR/myapp"
+  grep -q 'MYAPP_CALLER_PWD="$PWD"' "$SHIV_BIN_DIR/myapp"
+  ! grep -q 'export CALLER_PWD=' "$SHIV_BIN_DIR/myapp"
 }
 
-@test "shim: CALLER_PWD reflects actual cwd" {
+@test "shim: package-specific caller var reflects actual cwd" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
@@ -76,13 +77,41 @@ TASK
   [[ "$output" == *"/tmp"* ]]
 }
 
-@test "shim: CALLER_PWD overrides stale value from environment" {
+@test "shim: package-specific caller var overrides stale value from environment" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
 
-  # Even if CALLER_PWD is set in the environment, the shim should use $PWD
-  run bash -c "export CALLER_PWD='/some/stale/dir' && cd /tmp && '$SHIV_BIN_DIR/myapp' show-caller"
+  # Even if MYAPP_CALLER_PWD is set in the environment, the shim should use $PWD
+  run bash -c "export MYAPP_CALLER_PWD='/some/stale/dir' && cd /tmp && '$SHIV_BIN_DIR/myapp' show-caller"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/tmp"* ]]
+}
+
+@test "shim: caller var name is sanitized from package name" {
+  local repo_dir="$TEST_HOME/repos/my-tool"
+
+  mkdir -p "$repo_dir/.mise/tasks"
+  git -C "$repo_dir" init -q -b main
+  git -C "$repo_dir" config user.email "test@test.com"
+  git -C "$repo_dir" config user.name "Test"
+  echo '[tools]' > "$repo_dir/mise.toml"
+  cat > "$repo_dir/.mise/tasks/show-caller" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Print MY_TOOL_CALLER_PWD"
+echo "$MY_TOOL_CALLER_PWD"
+TASK
+  chmod +x "$repo_dir/.mise/tasks/show-caller"
+  git -C "$repo_dir" add .
+  git -C "$repo_dir" commit -q -m "init"
+  mise trust "$repo_dir/mise.toml" 2>/dev/null
+  mkdir -p "$SHIV_CACHE_DIR/completions"
+  printf 'show-caller\tPrint MY_TOOL_CALLER_PWD\n' > "$SHIV_CACHE_DIR/completions/my-tool.cache"
+
+  shiv install my-tool "$repo_dir" 2>/dev/null
+
+  grep -q 'MY_TOOL_CALLER_PWD="$PWD"' "$SHIV_BIN_DIR/my-tool"
+  run bash -c "cd /tmp && '$SHIV_BIN_DIR/my-tool' show-caller"
   [ "$status" -eq 0 ]
   [[ "$output" == *"/tmp"* ]]
 }


### PR DESCRIPTION
## Summary
- generate package-specific caller cwd variables in shiv shims (`<PACKAGE>_CALLER_PWD`)
- sanitize package names for env var names (`my-tool` -> `MY_TOOL_CALLER_PWD`)
- keep `shiv which` accepting `SHIV_CALLER_PWD` with legacy `CALLER_PWD` fallback during migration

## Verification
- `mise run test`
- `git diff --check`
- `codebase lint:caller-pwd-contract` across shiv/shimmer/sessions/modules/threads/codebase
- `codebase lint:shellcheck` across shiv/shimmer/sessions/modules/threads
