### PR TITLE
fix: complete shiv package aliases

### DIFF
--- a/.mise/tasks/completions/bash
+++ b/.mise/tasks/completions/bash
@@ -23,13 +23,99 @@ __shiv_rebuild_cache() {
   fi
 }
 
+__shiv_installed_packages() {
+  local registry="${SHIV_REGISTRY:-${XDG_CONFIG_HOME:-$HOME/.config}/shiv/registry.json}"
+  local packages_dir="${SHIV_PACKAGES_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/shiv/packages}"
+
+  if [ -f "$registry" ] && command -v jq >/dev/null 2>&1; then
+    jq -r 'keys[]' "$registry" 2>/dev/null | sort -u
+    return 0
+  fi
+
+  if [ -d "$packages_dir" ]; then
+    find "$packages_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | sort -u
+  fi
+}
+
+__shiv_source_packages() {
+  local sources="${SHIV_SOURCES:-}"
+  local sources_dir="${SHIV_SOURCES_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/shiv/sources}"
+  local files=()
+  local sf
+
+  if [ -n "$sources" ]; then
+    IFS=',' read -ra files <<< "$sources"
+  fi
+
+  if [ -d "$sources_dir" ]; then
+    for sf in "$sources_dir"/*.json; do
+      [ -f "$sf" ] || continue
+      files+=("$sf")
+    done
+  fi
+
+  if [ -n "${__SHIV_REPO_SOURCES:-}" ] && [ -f "$__SHIV_REPO_SOURCES" ]; then
+    files+=("$__SHIV_REPO_SOURCES")
+  fi
+
+  {
+    for sf in ${files[@]+"${files[@]}"}; do
+      sf="${sf## }"
+      sf="${sf%% }"
+      [ -f "$sf" ] || continue
+      jq -r 'keys[]' "$sf" 2>/dev/null
+    done
+  } | sort -u | comm -23 - <(__shiv_installed_packages)
+}
+
 HEADER
+
+printf '__SHIV_REPO_SOURCES=%q\n\n' "$MISE_CONFIG_ROOT/sources.json"
 
 # Emit completion function for a command name pointing at a repo
 _shiv_emit_bash_completion() {
   local cmd="$1" name="$2" repo="$3"
   local cache_file="$CACHE_BASE/$name.cache"
   local func_name="${cmd//[^a-zA-Z0-9_]/_}"
+
+  if [ "$cmd" = "shiv" ]; then
+    cat <<EOF
+_shiv_complete_${func_name}() {
+  local cache="${cache_file}"
+  local cur="\${COMP_WORDS[COMP_CWORD]}"
+  local subcmd=""
+
+  if [ "\$COMP_CWORD" -ge 1 ]; then
+    subcmd="\${COMP_WORDS[1]}"
+  fi
+
+  case "\$COMP_CWORD:\$subcmd" in
+    2:which|2:update)
+      local matches=""
+      matches="\$(compgen -W "\$(__shiv_installed_packages)" -- "\$cur")" || matches=""
+      COMPREPLY=( \$matches )
+      return
+      ;;
+    2:install)
+      local matches=""
+      matches="\$(compgen -W "\$(__shiv_source_packages)" -- "\$cur")" || matches=""
+      COMPREPLY=( \$matches )
+      return
+      ;;
+  esac
+
+  if [[ ! -s "\$cache" ]]; then
+    __shiv_rebuild_cache "$name" "$repo" "\$cache"
+  fi
+  if [[ -f "\$cache" && "\$COMP_CWORD" -eq 1 ]]; then
+    COMPREPLY=( \$(compgen -W "\$(cut -f1 "\$cache")" -- "\$cur") )
+  fi
+}
+complete -F _shiv_complete_${func_name} ${cmd}
+
+EOF
+    return
+  fi
 
   cat <<EOF
 _shiv_complete_${func_name}() {

--- a/.mise/tasks/completions/bash
+++ b/.mise/tasks/completions/bash
@@ -28,7 +28,7 @@ __shiv_installed_packages() {
   local packages_dir="${SHIV_PACKAGES_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/shiv/packages}"
 
   if [ -f "$registry" ] && command -v jq >/dev/null 2>&1; then
-    jq -r 'keys[]' "$registry" 2>/dev/null | sort -u
+    jq -r 'keys[], (.[] .aliases? // [] | .[])' "$registry" 2>/dev/null | sort -u
     return 0
   fi
 

--- a/.mise/tasks/completions/fish
+++ b/.mise/tasks/completions/fish
@@ -43,7 +43,7 @@ function __shiv_installed_packages
   end
 
   if test -f "$registry"; and command -q jq
-    jq -r 'keys[]' "$registry" 2>/dev/null | sort -u
+    jq -r 'keys[], (.[] .aliases? // [] | .[])' "$registry" 2>/dev/null | sort -u
   else if test -d "$packages_dir"
     find "$packages_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | sort -u
   end

--- a/.mise/tasks/completions/fish
+++ b/.mise/tasks/completions/fish
@@ -23,12 +23,91 @@ function __shiv_rebuild_cache
     > "$cache" 2>/dev/null; or true
 end
 
+function __shiv_installed_packages
+  set -l registry "$SHIV_REGISTRY"
+  if test -z "$registry"
+    if test -n "$XDG_CONFIG_HOME"
+      set registry "$XDG_CONFIG_HOME/shiv/registry.json"
+    else
+      set registry "$HOME/.config/shiv/registry.json"
+    end
+  end
+
+  set -l packages_dir "$SHIV_PACKAGES_DIR"
+  if test -z "$packages_dir"
+    if test -n "$XDG_DATA_HOME"
+      set packages_dir "$XDG_DATA_HOME/shiv/packages"
+    else
+      set packages_dir "$HOME/.local/share/shiv/packages"
+    end
+  end
+
+  if test -f "$registry"; and command -q jq
+    jq -r 'keys[]' "$registry" 2>/dev/null | sort -u
+  else if test -d "$packages_dir"
+    find "$packages_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | sort -u
+  end
+end
+
+function __shiv_source_packages
+  begin
+    if test -n "$SHIV_SOURCES"
+      for sf in (string split "," "$SHIV_SOURCES")
+        set sf (string trim "$sf")
+        test -f "$sf"; or continue
+        jq -r 'keys[]' "$sf" 2>/dev/null
+      end
+    end
+
+    set -l sources_dir "$SHIV_SOURCES_DIR"
+    if test -z "$sources_dir"
+      if test -n "$XDG_CONFIG_HOME"
+        set sources_dir "$XDG_CONFIG_HOME/shiv/sources"
+      else
+        set sources_dir "$HOME/.config/shiv/sources"
+      end
+    end
+
+    if test -d "$sources_dir"
+      for sf in "$sources_dir"/*.json
+        test -f "$sf"; or continue
+        jq -r 'keys[]' "$sf" 2>/dev/null
+      end
+    end
+
+    if test -n "$__SHIV_REPO_SOURCES"; and test -f "$__SHIV_REPO_SOURCES"
+      jq -r 'keys[]' "$__SHIV_REPO_SOURCES" 2>/dev/null
+    end
+  end | sort -u | comm -23 - (__shiv_installed_packages | psub)
+end
+
 HEADER
+
+printf 'set -g __SHIV_REPO_SOURCES %q\n\n' "$MISE_CONFIG_ROOT/sources.json"
 
 # Emit completion block for a command name pointing at a repo
 _shiv_emit_fish_completion() {
   local cmd="$1" name="$2" repo="$3"
   local cache_file="$CACHE_BASE/$name.cache"
+
+  if [ "$cmd" = "shiv" ]; then
+    cat <<EOF
+# completions for: ${cmd}
+complete -c ${cmd} -f -n 'not __fish_seen_subcommand_from install update which' -a '(begin
+  set -l cache "${cache_file}"
+  if not test -s "\$cache"
+    __shiv_rebuild_cache "$name" "$repo" "\$cache"
+  end
+  if test -f "\$cache"
+    cat "\$cache"
+  end
+end)'
+complete -c ${cmd} -f -n '__fish_seen_subcommand_from which update' -a '(__shiv_installed_packages)'
+complete -c ${cmd} -f -n '__fish_seen_subcommand_from install' -a '(__shiv_source_packages)'
+
+EOF
+    return
+  fi
 
   cat <<EOF
 # completions for: ${cmd}

--- a/.mise/tasks/completions/zsh
+++ b/.mise/tasks/completions/zsh
@@ -31,7 +31,7 @@ __shiv_installed_packages() {
   local packages_dir="${SHIV_PACKAGES_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/shiv/packages}"
 
   if [ -f "$registry" ] && command -v jq >/dev/null 2>&1; then
-    jq -r 'keys[]' "$registry" 2>/dev/null | sort -u
+    jq -r 'keys[], (.[] .aliases? // [] | .[])' "$registry" 2>/dev/null | sort -u
     return 0
   fi
 

--- a/.mise/tasks/completions/zsh
+++ b/.mise/tasks/completions/zsh
@@ -26,13 +26,98 @@ __shiv_rebuild_cache() {
   fi
 }
 
+__shiv_installed_packages() {
+  local registry="${SHIV_REGISTRY:-${XDG_CONFIG_HOME:-$HOME/.config}/shiv/registry.json}"
+  local packages_dir="${SHIV_PACKAGES_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/shiv/packages}"
+
+  if [ -f "$registry" ] && command -v jq >/dev/null 2>&1; then
+    jq -r 'keys[]' "$registry" 2>/dev/null | sort -u
+    return 0
+  fi
+
+  if [ -d "$packages_dir" ]; then
+    find "$packages_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | sort -u
+  fi
+}
+
+__shiv_source_packages() {
+  local sources="${SHIV_SOURCES:-}"
+  local sources_dir="${SHIV_SOURCES_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/shiv/sources}"
+  local sf
+
+  {
+    if [ -n "$sources" ]; then
+      for sf in ${(s:,:)sources}; do
+        sf="${sf## }"
+        sf="${sf%% }"
+        [ -f "$sf" ] || continue
+        jq -r 'keys[]' "$sf" 2>/dev/null
+      done
+    fi
+
+    if [ -d "$sources_dir" ]; then
+      for sf in "$sources_dir"/*.json(N); do
+        [ -f "$sf" ] || continue
+        jq -r 'keys[]' "$sf" 2>/dev/null
+      done
+    fi
+
+    if [ -n "${__SHIV_REPO_SOURCES:-}" ] && [ -f "$__SHIV_REPO_SOURCES" ]; then
+      jq -r 'keys[]' "$__SHIV_REPO_SOURCES" 2>/dev/null
+    fi
+  } | sort -u | comm -23 - <(__shiv_installed_packages)
+}
+
 HEADER
+
+printf '__SHIV_REPO_SOURCES=%q\n\n' "$MISE_CONFIG_ROOT/sources.json"
 
 # Emit completion function for a command name pointing at a repo
 _shiv_emit_zsh_completion() {
   local cmd="$1" name="$2" repo="$3"
   local cache_file="$CACHE_BASE/$name.cache"
   local func_name="${cmd//[^a-zA-Z0-9_]/_}"
+
+  if [ "$cmd" = "shiv" ]; then
+    cat <<EOF
+_shiv_complete_${func_name}() {
+  local cache="${cache_file}"
+
+  if (( CURRENT == 3 )); then
+    case "\${words[2]}" in
+      which|update)
+        local -a packages
+        packages=("\${(@f)\$(__shiv_installed_packages)}")
+        compadd -- "\${packages[@]}"
+        return
+        ;;
+      install)
+        local -a packages
+        packages=("\${(@f)\$(__shiv_source_packages)}")
+        compadd -- "\${packages[@]}"
+        return
+        ;;
+    esac
+  fi
+
+  if [[ ! -s "\$cache" ]]; then
+    __shiv_rebuild_cache "$name" "$repo" "\$cache"
+  fi
+  if [[ -f "\$cache" && "\$CURRENT" -eq 2 ]]; then
+    local -a completions
+    while IFS=\$'\\t' read -r task desc; do
+      # Escape colons in task names — _describe uses : as value/description separator
+      local escaped="\${task//:/\\\\:}"
+      completions+=("\${escaped}:\${desc}")
+    done < "\$cache"
+    _describe 'tasks' completions
+  fi
+}
+compdef _shiv_complete_${func_name} ${cmd}
+
+EOF
+    return
+  fi
 
   cat <<EOF
 _shiv_complete_${func_name}() {

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -116,6 +116,55 @@ setup() {
   [ -f "$SHIV_CACHE_DIR/completions/shiv.cache" ]
 }
 
+@test "bash: shiv which completes installed packages" {
+  shiv_register "alpha" "$REPO_DIR"
+  shiv_register "bravo" "$REPO_DIR"
+  shiv_cache_tasks "shiv" "$REPO_DIR"
+
+  eval "$(mise -C "$REPO_DIR" run -q completions:bash)"
+  COMP_WORDS=(shiv which "")
+  COMP_CWORD=2
+  COMPREPLY=()
+  _shiv_complete_shiv
+
+  [[ " ${COMPREPLY[*]} " == *" alpha "* ]]
+  [[ " ${COMPREPLY[*]} " == *" bravo "* ]]
+  [[ " ${COMPREPLY[*]} " != *" install "* ]]
+}
+
+@test "bash: shiv update completes installed packages by prefix" {
+  shiv_register "alpha" "$REPO_DIR"
+  shiv_register "bravo" "$REPO_DIR"
+  shiv_cache_tasks "shiv" "$REPO_DIR"
+
+  eval "$(mise -C "$REPO_DIR" run -q completions:bash)"
+  COMP_WORDS=(shiv update "a")
+  COMP_CWORD=2
+  COMPREPLY=()
+  _shiv_complete_shiv
+
+  [[ " ${COMPREPLY[*]} " == *" alpha "* ]]
+  [[ " ${COMPREPLY[*]} " != *" bravo "* ]]
+}
+
+@test "bash: shiv install completes only uninstalled source packages" {
+  mkdir -p "$SHIV_SOURCES_DIR"
+  cat > "$SHIV_SOURCES_DIR/test.json" <<JSON
+{"aardvark-test":"KnickKnackLabs/aardvark-test","zebra-test":"KnickKnackLabs/zebra-test"}
+JSON
+  shiv_register "zebra-test" "$REPO_DIR"
+  shiv_cache_tasks "shiv" "$REPO_DIR"
+
+  eval "$(mise -C "$REPO_DIR" run -q completions:bash)"
+  COMP_WORDS=(shiv install "")
+  COMP_CWORD=2
+  COMPREPLY=()
+  _shiv_complete_shiv
+
+  [[ " ${COMPREPLY[*]} " == *" aardvark-test "* ]]
+  [[ " ${COMPREPLY[*]} " != *" zebra-test "* ]]
+}
+
 # ============================================================================
 # Zsh completions
 # ============================================================================
@@ -140,6 +189,15 @@ setup() {
   [ "$status" -eq 0 ]
   # The escaping logic should be present
   echo "$output" | grep -qF 'task//:/\\:'
+}
+
+@test "zsh: shiv command completion has package subcommand branches" {
+  shiv_cache_tasks "shiv" "$REPO_DIR"
+  run mise -C "$REPO_DIR" run -q completions:zsh
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "__shiv_installed_packages"
+  echo "$output" | grep -q "__shiv_source_packages"
+  echo "$output" | grep -q "which|update"
 }
 
 @test "zsh: valid syntax" {
@@ -168,6 +226,15 @@ setup() {
   run mise -C "$REPO_DIR" run -q completions:fish
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "__shiv_rebuild_cache"
+}
+
+@test "fish: shiv command completion has package subcommand branches" {
+  shiv_cache_tasks "shiv" "$REPO_DIR"
+  run mise -C "$REPO_DIR" run -q completions:fish
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "__shiv_installed_packages"
+  echo "$output" | grep -q "__shiv_source_packages"
+  echo "$output" | grep -q "__fish_seen_subcommand_from which update"
 }
 
 @test "fish: valid syntax" {

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -132,8 +132,8 @@ setup() {
   [[ " ${COMPREPLY[*]} " != *" install "* ]]
 }
 
-@test "bash: shiv update completes installed packages by prefix" {
-  shiv_register "alpha" "$REPO_DIR"
+@test "bash: shiv update completes installed packages and aliases by prefix" {
+  shiv_register "alpha" "$REPO_DIR" "a-tool"
   shiv_register "bravo" "$REPO_DIR"
   shiv_cache_tasks "shiv" "$REPO_DIR"
 
@@ -144,6 +144,7 @@ setup() {
   _shiv_complete_shiv
 
   [[ " ${COMPREPLY[*]} " == *" alpha "* ]]
+  [[ " ${COMPREPLY[*]} " == *" a-tool "* ]]
   [[ " ${COMPREPLY[*]} " != *" bravo "* ]]
 }
 


### PR DESCRIPTION
`shiv which` and `shiv update` both accept package aliases, so include aliases in the installed-package completion list for bash, zsh, and fish.

Verification:
- `mise run test completions`
- `mise run test`
- `mise x shellcheck@0.11.0 -- shellcheck -x .mise/tasks/completions/bash .mise/tasks/completions/fish .mise/tasks/completions/zsh`
- `git diff --check origin/rho/shiv-command-completions-22...HEAD`
