### PR TITLE
fix: render shim task lists locally

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -30,6 +30,7 @@ if ! $has_target; then
     [[ "$(basename "$f" .bats)" == "$EXCLUDE" ]] && continue
     args+=("$f")
   done
+  exec bats --jobs 8 --parallel-binary-name rush "${args[@]}"
 fi
 
-bats "${args[@]}"
+exec bats "${args[@]}"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -25,12 +25,14 @@ for arg in "$@"; do
   fi
 done
 
+bats_args=()
+
 if ! $has_target; then
   for f in "$TEST_DIR"/*.bats; do
     [[ "$(basename "$f" .bats)" == "$EXCLUDE" ]] && continue
     args+=("$f")
   done
-  exec bats --jobs 8 --parallel-binary-name rush "${args[@]}"
+  bats_args+=(--jobs 8 --parallel-binary-name rush)
 fi
 
-exec bats "${args[@]}"
+exec bats ${bats_args[@]+"${bats_args[@]}"} ${args[@]+"${args[@]}"}

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -114,11 +114,59 @@ _shiv_ensure_task_map() {
   fi
 }
 
+_shiv_render_tasks_plain() {
+  awk -F '\t' '{ printf "%-12s  %-24s  %-16s  %s\n", \$1, \$2, \$3, \$4 }'
+}
+
+_shiv_render_tasks() {
+  if ! command -v jq >/dev/null 2>&1; then
+    exec mise -C "\$REPO" tasks --local
+  fi
+
+  local tmp repo_prefix
+  tmp=\$(mktemp)
+  repo_prefix="\$(cd "\$REPO" && pwd -P)/"
+  if ! mise -C "\$REPO" tasks --local --json 2>/dev/null \
+    | jq -r --arg repo_prefix "\$repo_prefix" '[.[] | select(.hide != true) | select(((.source // .file // "") | startswith(\$repo_prefix))) | (.name | split(":")) as \$p | {
+        group: (if (\$p | length) > 1 then \$p[0] else "root" end),
+        task: (if (\$p | length) > 1 then (\$p[1:] | join(":")) else .name end),
+        aliases: ((.aliases // []) | join(", ")),
+        description: (.description // "")
+      }]
+      | sort_by((if .group == "root" then "" else .group end), .task)
+      | .[]
+      | [.group, .task, .aliases, .description]
+      | @tsv' > "\$tmp" 2>/dev/null; then
+    rm -f "\$tmp"
+    exec mise -C "\$REPO" tasks --local
+  fi
+
+  if [ ! -s "\$tmp" ]; then
+    rm -f "\$tmp"
+    echo "No local tasks found."
+    return 0
+  fi
+
+  if command -v gum >/dev/null 2>&1 && [ -t 1 ]; then
+    {
+      printf 'Group\tTask\tAliases\tDescription\n'
+      cat "\$tmp"
+    } | gum table --print --separator \$'\t' --border rounded
+  else
+    {
+      printf 'Group\tTask\tAliases\tDescription\n'
+      cat "\$tmp"
+    } | _shiv_render_tasks_plain
+  fi
+
+  rm -f "\$tmp"
+}
+
 _shiv_handle_tasks() {
   if [ "\$HAS_TASKS_TASK" = "true" ]; then
     exec mise -C "\$REPO" run -q "\$@"
   fi
-  mise -C "\$REPO" tasks
+  _shiv_render_tasks
   local rc=\$?
   echo "" >&2
   echo "To override this output, create .mise/tasks/tasks in the package and reinstall." >&2
@@ -145,7 +193,7 @@ _shiv_handle_help() {
     fi
   fi
 
-  exec mise -C "\$REPO" tasks
+  _shiv_handle_tasks tasks
 }
 
 SCRIPT

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -120,7 +120,8 @@ _shiv_render_tasks_plain() {
 
 _shiv_render_tasks() {
   if ! command -v jq >/dev/null 2>&1; then
-    exec mise -C "\$REPO" tasks --local
+    echo "$name: jq not found, cannot render package-local task list" >&2
+    return 1
   fi
 
   local tmp repo_prefix
@@ -138,7 +139,8 @@ _shiv_render_tasks() {
       | [.group, .task, .aliases, .description]
       | @tsv' > "\$tmp" 2>/dev/null; then
     rm -f "\$tmp"
-    exec mise -C "\$REPO" tasks --local
+    echo "$name: failed to render package-local task list" >&2
+    return 1
   fi
 
   if [ ! -s "\$tmp" ]; then

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 bats = "1.13.0"
 gum = "0.17.0"
 jsonschema = "14.14.2"
+"aqua:shenwei356/rush" = "0.9.0"
 
 [_.codebase]
 lint = ["mise-settings", "bats-test-helper", "bats-test-task", "mcr-scope", "or-true", "shellcheck", "gum-table"]

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -120,15 +120,72 @@ TASK
 # tasks interception
 # ============================================================================
 
-@test "shim: 'tasks' lists available tasks when no tasks task exists" {
+@test "shim: 'tasks' lists available local tasks in formatted output" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
 
   run "$SHIV_BIN_DIR/myapp" tasks
   [ "$status" -eq 0 ]
+  [[ "$output" == *"Group"* ]]
+  [[ "$output" == *"Task"* ]]
+  [[ "$output" == *"Aliases"* ]]
+  [[ "$output" == *"Description"* ]]
+  [[ "$output" == *"root"* ]]
   [[ "$output" == *"show-caller"* ]]
+  [[ "$output" == *"Print MYAPP_CALLER_PWD"* ]]
+  [[ "$output" != *"mise-config"* ]]
   [[ "$output" == *"override"* ]]
+}
+
+@test "shim: 'tasks' excludes parent mise tasks" {
+  local repo_dir parent_dir
+  repo_dir=$(create_caller_repo "myapp")
+  parent_dir=$(dirname "$repo_dir")
+
+  mkdir -p "$parent_dir/.mise/tasks"
+  echo '[tools]' > "$parent_dir/mise.toml"
+  cat > "$parent_dir/.mise/tasks/parent-task" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Parent task should not leak"
+echo parent
+TASK
+  chmod +x "$parent_dir/.mise/tasks/parent-task"
+  mise trust "$parent_dir/mise.toml" 2>/dev/null
+
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" tasks
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"show-caller"* ]]
+  [[ "$output" != *"parent-task"* ]]
+  [[ "$output" != *"Parent task should not leak"* ]]
+}
+
+@test "shim: --help without package help renders only package-local tasks" {
+  local repo_dir parent_dir
+  repo_dir=$(create_caller_repo "myapp")
+  parent_dir=$(dirname "$repo_dir")
+
+  mkdir -p "$parent_dir/.mise/tasks"
+  echo '[tools]' > "$parent_dir/mise.toml"
+  cat > "$parent_dir/.mise/tasks/parent-task" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Parent task should not leak"
+echo parent
+TASK
+  chmod +x "$parent_dir/.mise/tasks/parent-task"
+  mise trust "$parent_dir/mise.toml" 2>/dev/null
+
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Group"* ]]
+  [[ "$output" == *"Task"* ]]
+  [[ "$output" == *"show-caller"* ]]
+  [[ "$output" != *"parent-task"* ]]
+  [[ "$output" != *"Parent task should not leak"* ]]
 }
 
 @test "shim: 'tasks' runs the package's tasks task when one exists" {
@@ -232,6 +289,19 @@ TASK
   [[ "$output" == *"PACKAGE_HELP_OUTPUT"* ]]
 }
 
+@test "shim: --help falls back to formatted local task list" {
+  local repo_dir
+  repo_dir=$(create_caller_repo "myapp")
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Group"* ]]
+  [[ "$output" == *"Task"* ]]
+  [[ "$output" == *"show-caller"* ]]
+  [[ "$output" != *"mise-config"* ]]
+}
+
 # ============================================================================
 # Space-to-colon resolution (integration)
 # ============================================================================
@@ -302,6 +372,19 @@ populate_task_map() {
   run "$SHIV_BIN_DIR/mytool" dev test unit
   [ "$status" -eq 0 ]
   [[ "$output" == *"DEV_TEST_UNIT"* ]]
+}
+
+@test "shim: tasks groups colon-namespaced tasks" {
+  local repo_dir
+  repo_dir=$(create_resolve_repo "mytool")
+  shiv install mytool "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/mytool" tasks
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Group"* ]]
+  [[ "$output" == *"root"*"greet"* ]]
+  [[ "$output" == *"greet"*"loud"* ]]
+  [[ "$output" == *"dev"*"test:unit"* ]]
 }
 
 @test "shim: spaces resolve with remaining args passed through" {

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -188,6 +188,37 @@ TASK
   [[ "$output" != *"Parent task should not leak"* ]]
 }
 
+@test "shim: tasks without jq fails closed instead of leaking parent tasks" {
+  local repo_dir parent_dir bin_dir
+  repo_dir=$(create_caller_repo "myapp")
+  parent_dir=$(dirname "$repo_dir")
+
+  mkdir -p "$parent_dir/.mise/tasks"
+  echo '[tools]' > "$parent_dir/mise.toml"
+  cat > "$parent_dir/.mise/tasks/parent-task" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Parent task should not leak"
+echo parent
+TASK
+  chmod +x "$parent_dir/.mise/tasks/parent-task"
+  mise trust "$parent_dir/mise.toml" 2>/dev/null
+
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  bin_dir="$BATS_TEST_TMPDIR/no-jq-bin"
+  mkdir -p "$bin_dir"
+  ln -s "$(command -v mise)" "$bin_dir/mise"
+  ln -s "$(command -v env)" "$bin_dir/env"
+  ln -s "$(command -v bash)" "$bin_dir/bash"
+  ln -s "$(command -v basename)" "$bin_dir/basename"
+
+  run env PATH="$bin_dir" "$SHIV_BIN_DIR/myapp" tasks
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"jq not found"* ]]
+  [[ "$output" != *"parent-task"* ]]
+  [[ "$output" != *"Parent task should not leak"* ]]
+}
+
 @test "shim: 'tasks' runs the package's tasks task when one exists" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")


### PR DESCRIPTION
## Summary

- Replace raw `mise tasks` output in generated shims with `mise tasks --local --json` rendered as a compact `Group / Task / Aliases / Description` table.
- Filter rendered tasks to files under the installed package root so parent-directory mise tasks do not leak into shiv package output.
- Group colon-namespaced tasks by their first segment (`windows:list` → `windows` / `list`) while keeping top-level tasks under `root`.
- Use `gum table --print` for TTY output when available, with a plain aligned fallback for non-TTY / missing gum.
- Keep `command tasks` overridable via package-owned `.mise/tasks/tasks`.
- Make `command --help` use the same formatted local task-list fallback when there is no explicit help task and no named default command help.
- Parallelize shiv's default full BATS run with `rush` (`bats --jobs 8 --parallel-binary-name rush`); targeted test invocations remain serial.

## Review focus

Please review against our shared patterns, not just test output:

- fold `notes/mise-conventions.md`
- fold `notes/mise-gotchas.md`
- fold `notes/bats-tool-testing.md`
- fold `notes/gum-cli-output.md`
- den `notes/gum.md`

Questions to check:

- Does the shim table renderer follow gum CLI-output conventions and degrade cleanly?
- Is `mise tasks --local --json` filtered tightly enough to avoid parent/global task leakage?
- Does the BATS parallelization follow the codebase#33 / notes#72 pattern without breaking targeted test runs?
- Does this improve the shiv package UX without removing the explicit `command tasks` escape hatch?

## Verification

- `mise install`
- `bash -n lib/shim.sh .mise/tasks/test`
- `mise run test test/shim.bats` — 29/29
- `mise run test` — 240/240
- manual generated-shim smoke against `butthair tasks` grouping
- `git diff --check`
- `codebase lint:mise-settings .` — OK
- `codebase lint:bats-test-task .` — OK

Known pre-existing lint noise when running broad codebase lints directly:

- `codebase lint:gum-table .` reports codebase's own gum-table fixture files.
- `codebase lint:shellcheck .` reports codebase/shiv test fixture violations and existing `.mise/tasks/lint/mcr-scope` SC2016.
