### PR TITLE
fix: render shim help fallback consistently

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -30,6 +30,7 @@ if ! $has_target; then
     [[ "$(basename "$f" .bats)" == "$EXCLUDE" ]] && continue
     args+=("$f")
   done
+  exec bats --jobs 8 --parallel-binary-name rush "${args[@]}"
 fi
 
-bats "${args[@]}"
+exec bats "${args[@]}"

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -114,11 +114,49 @@ _shiv_ensure_task_map() {
   fi
 }
 
+_shiv_render_tasks_plain() {
+  awk -F '\t' '{ printf "%-24s  %-16s  %s\n", \$1, \$2, \$3 }'
+}
+
+_shiv_render_tasks() {
+  if ! command -v jq >/dev/null 2>&1; then
+    exec mise -C "\$REPO" tasks --local
+  fi
+
+  local tmp
+  tmp=\$(mktemp)
+  if ! mise -C "\$REPO" tasks --local --json 2>/dev/null \
+    | jq -r '.[] | select(.hide != true) | [.name, ((.aliases // []) | join(", ")), (.description // "")] | @tsv' > "\$tmp" 2>/dev/null; then
+    rm -f "\$tmp"
+    exec mise -C "\$REPO" tasks --local
+  fi
+
+  if [ ! -s "\$tmp" ]; then
+    rm -f "\$tmp"
+    echo "No local tasks found."
+    return 0
+  fi
+
+  if command -v gum >/dev/null 2>&1 && [ -t 1 ]; then
+    {
+      printf 'Task\tAliases\tDescription\n'
+      cat "\$tmp"
+    } | gum table --print --separator \$'\t' --border rounded
+  else
+    {
+      printf 'Task\tAliases\tDescription\n'
+      cat "\$tmp"
+    } | _shiv_render_tasks_plain
+  fi
+
+  rm -f "\$tmp"
+}
+
 _shiv_handle_tasks() {
   if [ "\$HAS_TASKS_TASK" = "true" ]; then
     exec mise -C "\$REPO" run -q "\$@"
   fi
-  mise -C "\$REPO" tasks
+  _shiv_render_tasks
   local rc=\$?
   echo "" >&2
   echo "To override this output, create .mise/tasks/tasks in the package and reinstall." >&2

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -183,7 +183,8 @@ _shiv_handle_help() {
     fi
   fi
 
-  exec mise -C "\$REPO" tasks
+  _shiv_render_tasks
+  exit \$?
 }
 
 SCRIPT

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 bats = "1.13.0"
 gum = "0.17.0"
 jsonschema = "14.14.2"
+"aqua:shenwei356/rush" = "0.9.0"
 
 [_.codebase]
 lint = ["mise-settings", "bats-test-helper", "bats-test-task", "mcr-scope", "or-true", "shellcheck", "gum-table"]

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -120,14 +120,19 @@ TASK
 # tasks interception
 # ============================================================================
 
-@test "shim: 'tasks' lists available tasks when no tasks task exists" {
+@test "shim: 'tasks' lists available local tasks in formatted output" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
 
   run "$SHIV_BIN_DIR/myapp" tasks
   [ "$status" -eq 0 ]
+  [[ "$output" == *"Task"* ]]
+  [[ "$output" == *"Aliases"* ]]
+  [[ "$output" == *"Description"* ]]
   [[ "$output" == *"show-caller"* ]]
+  [[ "$output" == *"Print MYAPP_CALLER_PWD"* ]]
+  [[ "$output" != *"mise-config"* ]]
   [[ "$output" == *"override"* ]]
 }
 

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -188,6 +188,21 @@ TASK
   echo "$repo_dir"
 }
 
+@test "shim: help lists available local tasks in formatted output" {
+  local repo_dir
+  repo_dir=$(create_caller_repo "myapp")
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Task"* ]]
+  [[ "$output" == *"Aliases"* ]]
+  [[ "$output" == *"Description"* ]]
+  [[ "$output" == *"show-caller"* ]]
+  [[ "$output" == *"Print MYAPP_CALLER_PWD"* ]]
+  [[ "$output" != *"mise-config"* ]]
+}
+
 @test "shim: --help routes to named default task help" {
   local repo_dir
   repo_dir=$(create_named_default_repo "myapp")


### PR DESCRIPTION
## Summary

- Route the generic shim help fallback through the new local task renderer
- Add regression coverage for formatted `<tool> help` output when no package-owned help/default task exists

## Verification

- `mise run test shim`
- `mise run test`
- `mise run test completions`
- `git diff --check origin/k7r2/nice-shim-tasks...HEAD`
- `bash -n lib/shim.sh .mise/tasks/test`
- `shellcheck -x -P lib lib/shim.sh .mise/tasks/test`
