### PR TITLE
fix: keep shim task lists package-local

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -30,6 +30,7 @@ if ! $has_target; then
     [[ "$(basename "$f" .bats)" == "$EXCLUDE" ]] && continue
     args+=("$f")
   done
+  exec bats --jobs 8 --parallel-binary-name rush "${args[@]}"
 fi
 
-bats "${args[@]}"
+exec bats "${args[@]}"

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -123,10 +123,11 @@ _shiv_render_tasks() {
     exec mise -C "\$REPO" tasks --local
   fi
 
-  local tmp
+  local tmp repo_prefix
   tmp=\$(mktemp)
+  repo_prefix="\${REPO%/}/"
   if ! mise -C "\$REPO" tasks --local --json 2>/dev/null \
-    | jq -r '.[] | select(.hide != true) | [.name, ((.aliases // []) | join(", ")), (.description // "")] | @tsv' > "\$tmp" 2>/dev/null; then
+    | jq -r --arg repo_prefix "\$repo_prefix" '.[] | select(.hide != true) | select(((.source // .file // "") | startswith(\$repo_prefix))) | [.name, ((.aliases // []) | join(", ")), (.description // "")] | @tsv' > "\$tmp" 2>/dev/null; then
     rm -f "\$tmp"
     exec mise -C "\$REPO" tasks --local
   fi
@@ -183,7 +184,8 @@ _shiv_handle_help() {
     fi
   fi
 
-  exec mise -C "\$REPO" tasks
+  _shiv_render_tasks
+  exit \$?
 }
 
 SCRIPT

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -114,11 +114,49 @@ _shiv_ensure_task_map() {
   fi
 }
 
+_shiv_render_tasks_plain() {
+  awk -F '\t' '{ printf "%-24s  %-16s  %s\n", \$1, \$2, \$3 }'
+}
+
+_shiv_render_tasks() {
+  if ! command -v jq >/dev/null 2>&1; then
+    exec mise -C "\$REPO" tasks --local
+  fi
+
+  local tmp
+  tmp=\$(mktemp)
+  if ! mise -C "\$REPO" tasks --local --json 2>/dev/null \
+    | jq -r '.[] | select(.hide != true) | [.name, ((.aliases // []) | join(", ")), (.description // "")] | @tsv' > "\$tmp" 2>/dev/null; then
+    rm -f "\$tmp"
+    exec mise -C "\$REPO" tasks --local
+  fi
+
+  if [ ! -s "\$tmp" ]; then
+    rm -f "\$tmp"
+    echo "No local tasks found."
+    return 0
+  fi
+
+  if command -v gum >/dev/null 2>&1 && [ -t 1 ]; then
+    {
+      printf 'Task\tAliases\tDescription\n'
+      cat "\$tmp"
+    } | gum table --print --separator \$'\t' --border rounded
+  else
+    {
+      printf 'Task\tAliases\tDescription\n'
+      cat "\$tmp"
+    } | _shiv_render_tasks_plain
+  fi
+
+  rm -f "\$tmp"
+}
+
 _shiv_handle_tasks() {
   if [ "\$HAS_TASKS_TASK" = "true" ]; then
     exec mise -C "\$REPO" run -q "\$@"
   fi
-  mise -C "\$REPO" tasks
+  _shiv_render_tasks
   local rc=\$?
   echo "" >&2
   echo "To override this output, create .mise/tasks/tasks in the package and reinstall." >&2

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 bats = "1.13.0"
 gum = "0.17.0"
 jsonschema = "14.14.2"
+"aqua:shenwei356/rush" = "0.9.0"
 
 [_.codebase]
 lint = ["mise-settings", "bats-test-helper", "bats-test-task", "mcr-scope", "or-true", "shellcheck", "gum-table"]

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -136,6 +136,55 @@ TASK
   [[ "$output" == *"override"* ]]
 }
 
+@test "shim: 'tasks' excludes parent mise tasks" {
+  local repo_dir parent_dir
+  repo_dir=$(create_caller_repo "myapp")
+  parent_dir=$(dirname "$repo_dir")
+
+  mkdir -p "$parent_dir/.mise/tasks"
+  echo '[tools]' > "$parent_dir/mise.toml"
+  cat > "$parent_dir/.mise/tasks/parent-task" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Parent task should not leak"
+echo parent
+TASK
+  chmod +x "$parent_dir/.mise/tasks/parent-task"
+  mise trust "$parent_dir/mise.toml" 2>/dev/null
+
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" tasks
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"show-caller"* ]]
+  [[ "$output" != *"parent-task"* ]]
+  [[ "$output" != *"Parent task should not leak"* ]]
+}
+
+@test "shim: --help without package help renders only package-local tasks" {
+  local repo_dir parent_dir
+  repo_dir=$(create_caller_repo "myapp")
+  parent_dir=$(dirname "$repo_dir")
+
+  mkdir -p "$parent_dir/.mise/tasks"
+  echo '[tools]' > "$parent_dir/mise.toml"
+  cat > "$parent_dir/.mise/tasks/parent-task" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Parent task should not leak"
+echo parent
+TASK
+  chmod +x "$parent_dir/.mise/tasks/parent-task"
+  mise trust "$parent_dir/mise.toml" 2>/dev/null
+
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Task"* ]]
+  [[ "$output" == *"show-caller"* ]]
+  [[ "$output" != *"parent-task"* ]]
+  [[ "$output" != *"Parent task should not leak"* ]]
+}
+
 @test "shim: 'tasks' runs the package's tasks task when one exists" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -120,14 +120,19 @@ TASK
 # tasks interception
 # ============================================================================
 
-@test "shim: 'tasks' lists available tasks when no tasks task exists" {
+@test "shim: 'tasks' lists available local tasks in formatted output" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")
   shiv install myapp "$repo_dir" 2>/dev/null
 
   run "$SHIV_BIN_DIR/myapp" tasks
   [ "$status" -eq 0 ]
+  [[ "$output" == *"Task"* ]]
+  [[ "$output" == *"Aliases"* ]]
+  [[ "$output" == *"Description"* ]]
   [[ "$output" == *"show-caller"* ]]
+  [[ "$output" == *"Print MYAPP_CALLER_PWD"* ]]
+  [[ "$output" != *"mise-config"* ]]
   [[ "$output" == *"override"* ]]
 }
 


### PR DESCRIPTION
## Summary

- Filter rendered shim task rows by the installed package root so parent-directory mise tasks do not leak into `<pkg> tasks`.
- Route generic shim `--help` through the same renderer/filter when the package does not provide its own help/default command.
- Add regressions for parent-task leakage on both `tasks` and `--help`.

## Verification

- `bash -n lib/shim.sh .mise/tasks/test`
- `mise run test test/shim.bats` — 27/27
- `mise run test` — 238/238
- `git diff --check origin/k7r2/nice-shim-tasks...HEAD`
- `/home/runner/.local/share/mise/installs/shiv-codebase/0.2.0/bin/codebase lint:bats-test-task .`

Note: `/home/runner/.local/share/mise/installs/shiv-codebase/0.2.0/bin/codebase lint:mise-settings .` reports `missing task_output = "interleave"` in this runner even though `mise.toml` contains it; I am not treating that as verified here.
