### PR TITLE
fix: fail closed without jq in shim task rendering

### DIFF
--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -120,7 +120,8 @@ _shiv_render_tasks_plain() {
 
 _shiv_render_tasks() {
   if ! command -v jq >/dev/null 2>&1; then
-    exec mise -C "\$REPO" tasks --local
+    echo "$name: jq not found, cannot render package-local task list" >&2
+    return 1
   fi
 
   local tmp repo_prefix
@@ -138,7 +139,8 @@ _shiv_render_tasks() {
       | [.group, .task, .aliases, .description]
       | @tsv' > "\$tmp" 2>/dev/null; then
     rm -f "\$tmp"
-    exec mise -C "\$REPO" tasks --local
+    echo "$name: failed to render package-local task list" >&2
+    return 1
   fi
 
   if [ ! -s "\$tmp" ]; then

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -188,6 +188,37 @@ TASK
   [[ "$output" != *"Parent task should not leak"* ]]
 }
 
+@test "shim: tasks without jq fails closed instead of leaking parent tasks" {
+  local repo_dir parent_dir bin_dir
+  repo_dir=$(create_caller_repo "myapp")
+  parent_dir=$(dirname "$repo_dir")
+
+  mkdir -p "$parent_dir/.mise/tasks"
+  echo '[tools]' > "$parent_dir/mise.toml"
+  cat > "$parent_dir/.mise/tasks/parent-task" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Parent task should not leak"
+echo parent
+TASK
+  chmod +x "$parent_dir/.mise/tasks/parent-task"
+  mise trust "$parent_dir/mise.toml" 2>/dev/null
+
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  bin_dir="$BATS_TEST_TMPDIR/no-jq-bin"
+  mkdir -p "$bin_dir"
+  ln -s "$(command -v mise)" "$bin_dir/mise"
+  ln -s "$(command -v env)" "$bin_dir/env"
+  ln -s "$(command -v bash)" "$bin_dir/bash"
+  ln -s "$(command -v basename)" "$bin_dir/basename"
+
+  run env PATH="$bin_dir" "$SHIV_BIN_DIR/myapp" tasks
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"jq not found"* ]]
+  [[ "$output" != *"parent-task"* ]]
+  [[ "$output" != *"Parent task should not leak"* ]]
+}
+
 @test "shim: 'tasks' runs the package's tasks task when one exists" {
   local repo_dir
   repo_dir=$(create_caller_repo "myapp")


### PR DESCRIPTION
## Summary

Follow-up for #117: the package-local task renderer filtered parent tasks only on the jq path, but its no-jq / render-failure fallback executed raw `mise -C "$REPO" tasks --local`, which can leak parent mise tasks again.

This fails closed instead of falling back to the unfiltered raw output, and adds a regression that removes `jq` from PATH while a parent task exists.

## Verification

- `mise run test shim` (30/30)
- `mise run test` (241/241)
- `mise run test completions` (28/28; zsh/fish syntax skipped because shells absent)
- `git diff --check`
- `bash -n lib/shim.sh .mise/tasks/test`
- `shellcheck -x -P lib lib/shim.sh .mise/tasks/test`
- `codebase lint:mise-settings "$PWD"`
- `codebase lint:gum-table "$PWD"`
