### PR TITLE
Make bare/latest installs resolve latest release

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -95,11 +95,30 @@ else
     CURRENT_BRANCH=$(git -C "$TOOL_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
     if [ "$REF" != "$EXISTING_REF" ] || [ "$REF_MODE" != "$EXISTING_MODE" ]; then
       echo "  Ref changed (${EXISTING_MODE:-legacy}:${EXISTING_REF:-unknown} → ${REF_MODE}:${REF}), switching..."
-      git -C "$TOOL_PATH" fetch origin 2>&1 | sed 's/^/  /'
-      git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+      case "$REF_MODE" in
+        release|tag)
+          git -C "$TOOL_PATH" fetch --tags origin 2>&1 | sed 's/^/  /'
+          ;;
+        branch)
+          git -C "$TOOL_PATH" config --add remote.origin.fetch "+refs/heads/$REF:refs/remotes/origin/$REF"
+          git -C "$TOOL_PATH" fetch origin "+refs/heads/$REF:refs/remotes/origin/$REF" 2>&1 | sed 's/^/  /'
+          ;;
+        commit)
+          git -C "$TOOL_PATH" fetch --depth 1 origin "$REF" 2>&1 | sed 's/^/  /'
+          ;;
+      esac
+      if [ "$REF_MODE" = "branch" ]; then
+        git -C "$TOOL_PATH" checkout -B "$REF" "origin/$REF" 2>&1 | sed 's/^/  /'
+        git -C "$TOOL_PATH" branch --set-upstream-to="origin/$REF" "$REF" 2>&1 | sed 's/^/  /'
+      else
+        git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+      fi
     elif [ "$REF_MODE" = "branch" ] && [ "$REF" != "$CURRENT_BRANCH" ]; then
       echo "  Branch changed (${CURRENT_BRANCH:-detached} → ${REF}), switching..."
-      git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+      git -C "$TOOL_PATH" config --add remote.origin.fetch "+refs/heads/$REF:refs/remotes/origin/$REF"
+      git -C "$TOOL_PATH" fetch origin "+refs/heads/$REF:refs/remotes/origin/$REF" 2>&1 | sed 's/^/  /'
+      git -C "$TOOL_PATH" checkout -B "$REF" "origin/$REF" 2>&1 | sed 's/^/  /'
+      git -C "$TOOL_PATH" branch --set-upstream-to="origin/$REF" "$REF" 2>&1 | sed 's/^/  /'
     fi
   fi
 

--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Install a tool — from the package index or a local path"
-#USAGE arg "<name>" help="Package name, optionally with ref (e.g., shimmer, frames@v1.0.0)"
+#USAGE arg "<name>" help="Package name, optionally with ref (bare/@latest release, @main branch, @v1.0.0 tag)"
 #USAGE arg "[path]" help="Local path to repo (optional — if omitted, clones from package index)"
 #USAGE flag "--as <alias>" var=#true help="Command alias(es) — creates symlinks to the package shim"
 set -euo pipefail
@@ -13,10 +13,14 @@ NAME="${usage_name}"
 LOCAL_PATH="${usage_path:-}"
 SEP='|'
 
-# Parse name@ref syntax
+# Parse name@ref syntax. Bare installs and @latest are release-channel
+# installs; explicit branches/tags/commits preserve their requested intent.
+REQUESTED_REF=""
 REF=""
+REF_TYPE=""
+REF_MODE=""
 if [[ "$NAME" == *@* ]]; then
-  REF="${NAME#*@}"
+  REQUESTED_REF="${NAME#*@}"
   NAME="${NAME%%@*}"
 fi
 
@@ -28,10 +32,11 @@ fi
 
 if [ -n "$LOCAL_PATH" ]; then
   # Local install — point at an existing repo
-  if [ -n "$REF" ]; then
+  if [ -n "$REQUESTED_REF" ]; then
     echo "Error: @ref syntax is not supported with local path installs" >&2
     exit 1
   fi
+  REF_MODE="local"
   TOOL_PATH="$(cd "$LOCAL_PATH" && pwd)"
 else
   # Package install — look up in sources and clone
@@ -52,52 +57,69 @@ else
     exit 1
   fi
 
-  # Detect ref type if a ref was specified
-  REF_TYPE=""
-  if [ -n "$REF" ]; then
+  # Resolve install intent. Bare installs and @latest use the newest stable
+  # semver-ish release tag. Branch tracking is explicit: install name@main.
+  if [ -z "$REQUESTED_REF" ] || [ "$REQUESTED_REF" = "latest" ]; then
+    latest_status=0
+    REF=$(shiv_latest_release_tag "$GH_REPO") || latest_status=$?
+    if [ "$latest_status" -eq 1 ]; then
+      echo "" >&2
+      echo "  ✗ No release tags found for $NAME" >&2
+      echo "    Use 'shiv install ${NAME}@main' to track the main branch," >&2
+      echo "    or 'shiv install ${NAME}@<branch>' for another branch." >&2
+      echo "" >&2
+      exit 1
+    elif [ "$latest_status" -ne 0 ]; then
+      exit "$latest_status"
+    fi
+    REF_TYPE="tag"
+    REF_MODE="release"
+  else
+    REF="$REQUESTED_REF"
     REF_TYPE=$(shiv_detect_ref_type "$GH_REPO" "$REF") || exit 1
+    case "$REF_TYPE" in
+      branch) REF_MODE="branch" ;;
+      tag) REF_MODE="tag" ;;
+      commit) REF_MODE="commit" ;;
+    esac
   fi
 
   TOOL_PATH="$SHIV_PACKAGES_DIR/$NAME"
 
-  # If already cloned but ref changed, switch to the new ref
+  # If already cloned but the resolved ref or intent changed, switch in-place
+  # rather than deleting a directory we might be running from (e.g., shiv
+  # reinstalling itself).
   if [ -d "$TOOL_PATH" ]; then
     EXISTING_REF=$(shiv_registry_ref "$NAME")
-    # Normalize: if the requested ref matches the current branch, treat as same
+    EXISTING_MODE=$(shiv_registry_ref_mode "$NAME")
     CURRENT_BRANCH=$(git -C "$TOOL_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-    if [ "$REF" != "$EXISTING_REF" ] && [ "$REF" != "$CURRENT_BRANCH" ]; then
-      # Switch ref in-place (fetch + checkout) to avoid deleting a directory
-      # we might be running from (e.g., shiv reinstalling itself)
-      if [ -n "$EXISTING_REF" ] && [ -z "$REF" ]; then
-        echo "  ⚠ Unpinning from $EXISTING_REF — $NAME will now track the default branch"
-      else
-        echo "  Ref changed (${EXISTING_REF:-default} → ${REF:-default}), switching..."
-      fi
+    if [ "$REF" != "$EXISTING_REF" ] || [ "$REF_MODE" != "$EXISTING_MODE" ]; then
+      echo "  Ref changed (${EXISTING_MODE:-legacy}:${EXISTING_REF:-unknown} → ${REF_MODE}:${REF}), switching..."
       git -C "$TOOL_PATH" fetch origin 2>&1 | sed 's/^/  /'
-      # Empty ref means "back to default branch"
-      CHECKOUT_TARGET="${REF:-$(git -C "$TOOL_PATH" remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')}"
-      git -C "$TOOL_PATH" checkout "$CHECKOUT_TARGET" 2>&1 | sed 's/^/  /'
-    elif [ "$REF" != "$EXISTING_REF" ] && [ "$REF" = "$CURRENT_BRANCH" ]; then
-      # e.g., installing tool@main when already on main — just update the registry
-      :
+      git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+    elif [ "$REF_MODE" = "branch" ] && [ "$REF" != "$CURRENT_BRANCH" ]; then
+      echo "  Branch changed (${CURRENT_BRANCH:-detached} → ${REF}), switching..."
+      git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
     fi
   fi
 
   if [ -d "$TOOL_PATH" ]; then
-    # Already cloned, same ref
     echo "  Already cloned: $TOOL_PATH"
-    if git -C "$TOOL_PATH" symbolic-ref HEAD &>/dev/null; then
-      gum spin --title "  Pulling latest..." --show-error -- git -C "$TOOL_PATH" pull --ff-only
-    else
-      echo "  Pinned to ${REF} — skipping pull"
-    fi
+    case "$REF_MODE" in
+      branch)
+        gum spin --title "  Pulling latest from $REF..." --show-error -- git -C "$TOOL_PATH" pull --ff-only
+        ;;
+      release)
+        echo "  Release $REF already installed — skipping pull"
+        ;;
+      tag|commit)
+        echo "  Pinned to $REF — skipping pull"
+        ;;
+    esac
   else
     mkdir -p "$SHIV_PACKAGES_DIR"
     CLONE_URL="https://github.com/$GH_REPO.git"
     case "$REF_TYPE" in
-      "")
-        gum spin --title "  Cloning $GH_REPO..." --show-error -- git clone --single-branch "$CLONE_URL" "$TOOL_PATH"
-        ;;
       branch)
         gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --branch "$REF" --single-branch "$CLONE_URL" "$TOOL_PATH"
         ;;
@@ -129,9 +151,9 @@ fi
 
 shiv_create_shim "$NAME" "$TOOL_PATH"
 if [ -n "${usage_as:-}" ]; then
-  SHIV_REF="$REF" shiv_register "$NAME" "$TOOL_PATH" "${ALIASES[@]}"
+  SHIV_REF="$REF" SHIV_REF_MODE="$REF_MODE" shiv_register "$NAME" "$TOOL_PATH" "${ALIASES[@]}"
 else
-  SHIV_REF="$REF" shiv_register "$NAME" "$TOOL_PATH"
+  SHIV_REF="$REF" SHIV_REF_MODE="$REF_MODE" shiv_register "$NAME" "$TOOL_PATH"
 fi
 shiv_cache_tasks "$NAME" "$TOOL_PATH"
 shiv_cache_task_map "$NAME" "$TOOL_PATH"

--- a/.mise/tasks/update
+++ b/.mise/tasks/update
@@ -10,19 +10,184 @@ shiv_init_registry
 TARGET="${usage_name:-}"
 SEP='|'
 
-# Collect results for summary table
+# Collect results for summary table.
 # Each entry: PACKAGE|BRANCH|VERSION|STATUS|DETAIL
 RESULTS=()
 
-# Update a single package, appending result to RESULTS array
+add_result() {
+  RESULTS+=("$1${SEP}$2${SEP}$3${SEP}$4${SEP}$5")
+}
+
+package_version() {
+  local repo="$1"
+  local fallback="$2"
+  local dirty_marker=""
+  local tag
+
+  if [ -n "$(git -C "$repo" status --porcelain 2>/dev/null | head -1)" ]; then
+    dirty_marker="*"
+  fi
+
+  tag=$(git -C "$repo" describe --tags --exact-match HEAD 2>/dev/null || echo "")
+  if [ -n "$tag" ]; then
+    printf '%s%s\n' "$tag" "$dirty_marker"
+  else
+    printf '%s%s\n' "$fallback" "$dirty_marker"
+  fi
+}
+
+refresh_package() {
+  local name="$1" repo="$2"
+  local aliases=()
+
+  shiv_create_shim "$name" "$repo"
+  shiv_cache_tasks "$name" "$repo"
+  shiv_cache_task_map "$name" "$repo"
+
+  while IFS= read -r _alias; do
+    [ -n "$_alias" ] && aliases+=("$_alias")
+  done < <(shiv_registry_aliases "$name")
+
+  if [ ${#aliases[@]} -gt 0 ]; then
+    shiv_create_alias_symlinks "$name" "${aliases[@]}"
+  fi
+}
+
+update_branch_like() {
+  local name="$1" repo="$2" mode="$3" ref="$4"
+  local branch before after output version reason count tag
+
+  branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+
+  if [ "$mode" = "branch" ] && [ -n "$ref" ] && [ "$branch" != "$ref" ]; then
+    if ! output=$(git -C "$repo" checkout "$ref" 2>&1); then
+      reason=$(echo "$output" | grep -m1 -E '^(fatal|error):' || echo "$output" | grep -v '^$' | tail -1)
+      before=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+      version=$(package_version "$repo" "$before")
+      add_result "$name" "$branch" "$version" "⚠" "$reason"
+      echo "  ⚠ $name — $reason"
+      return 1
+    fi
+    branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+  fi
+
+  if ! git -C "$repo" symbolic-ref HEAD &>/dev/null; then
+    before=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    version=$(package_version "$repo" "$before")
+    add_result "$name" "$branch" "$version" "·" "detached HEAD — skipping"
+    echo "  · $name  detached HEAD — skipping"
+    return 0
+  fi
+
+  before=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+  if output=$(git -C "$repo" pull --ff-only 2>&1); then
+    after=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    version=$(package_version "$repo" "$after")
+    refresh_package "$name" "$repo"
+
+    if [ "$before" = "$after" ]; then
+      add_result "$name" "$branch" "$version" "✓" "already up to date"
+      echo "  ✓ $name — already up to date"
+    else
+      count=$(git -C "$repo" rev-list --count "$before".."$after" 2>/dev/null || echo "?")
+      add_result "$name" "$branch" "$version" "✓" "${before} → ${after} (${count} commits)"
+      echo "  ✓ $name — $before → $after ($count commits)"
+    fi
+    return 0
+  fi
+
+  reason=$(echo "$output" | grep -m1 -E '^(fatal|error):' || echo "$output" | grep -v '^$' | tail -1)
+  version=$(package_version "$repo" "$before")
+  add_result "$name" "$branch" "$version" "⚠" "$reason"
+  echo "  ⚠ $name — $reason"
+  return 1
+}
+
+update_release() {
+  local name="$1" repo="$2" ref="$3"
+  local remote_url latest latest_status before after branch version reason count output current_tag
+
+  branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+  before=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  version=$(package_version "$repo" "$before")
+
+  if [ -n "$(git -C "$repo" status --porcelain 2>/dev/null | head -1)" ]; then
+    reason="dirty working tree — refusing to switch release tags"
+    add_result "$name" "$branch" "$version" "⚠" "$reason"
+    echo "  ⚠ $name — $reason"
+    return 1
+  fi
+
+  remote_url=$(git -C "$repo" remote get-url origin 2>/dev/null || echo "")
+  if [ -z "$remote_url" ]; then
+    reason="no origin remote for release lookup"
+    add_result "$name" "$branch" "$version" "⚠" "$reason"
+    echo "  ⚠ $name — $reason"
+    return 1
+  fi
+
+  latest_status=0
+  latest=$(shiv_latest_release_tag_from_url "$remote_url") || latest_status=$?
+  if [ "$latest_status" -eq 1 ]; then
+    reason="no release tags found"
+    add_result "$name" "$branch" "$version" "⚠" "$reason"
+    echo "  ⚠ $name — $reason"
+    return 1
+  elif [ "$latest_status" -ne 0 ]; then
+    reason="failed to query release tags"
+    add_result "$name" "$branch" "$version" "⚠" "$reason"
+    echo "  ⚠ $name — $reason"
+    return 1
+  fi
+
+  current_tag=$(git -C "$repo" describe --tags --exact-match HEAD 2>/dev/null || echo "")
+  if [ "$ref" = "$latest" ] && [ "$current_tag" = "$latest" ]; then
+    refresh_package "$name" "$repo"
+    add_result "$name" "$branch" "$version" "✓" "already on latest release"
+    echo "  ✓ $name — already on latest release ($latest)"
+    return 0
+  fi
+
+  if ! output=$(git -C "$repo" fetch --tags origin 2>&1); then
+    reason=$(echo "$output" | grep -m1 -E '^(fatal|error):' || echo "$output" | grep -v '^$' | tail -1)
+    add_result "$name" "$branch" "$version" "⚠" "$reason"
+    echo "  ⚠ $name — $reason"
+    return 1
+  fi
+
+  if ! output=$(git -C "$repo" checkout "$latest" 2>&1); then
+    reason=$(echo "$output" | grep -m1 -E '^(fatal|error):' || echo "$output" | grep -v '^$' | tail -1)
+    add_result "$name" "$branch" "$version" "⚠" "$reason"
+    echo "  ⚠ $name — $reason"
+    return 1
+  fi
+
+  after=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+  version=$(package_version "$repo" "$after")
+  shiv_registry_set_ref "$name" "$latest" "release"
+  refresh_package "$name" "$repo"
+
+  if [ "$before" = "$after" ]; then
+    add_result "$name" "$branch" "$version" "✓" "release intent recorded as $latest"
+    echo "  ✓ $name — release intent recorded as $latest"
+  else
+    count=$(git -C "$repo" rev-list --count "$before".."$after" 2>/dev/null || echo "?")
+    add_result "$name" "$branch" "$version" "✓" "${ref:-unknown} → ${latest} (${count} commits)"
+    echo "  ✓ $name — ${ref:-unknown} → $latest ($count commits)"
+  fi
+}
+
+# Update a single package, appending result to RESULTS array.
 update_one() {
   local name="$1"
-  local repo
+  local repo resolved mode ref branch version reason
+
   repo=$(shiv_registry_path "$name")
 
-  # If not a direct package name, try resolving as alias
+  # If not a direct package name, try resolving as alias.
   if [ -z "$repo" ]; then
-    local resolved
     resolved=$(shiv_registry_resolve "$name")
     if [ -n "$resolved" ]; then
       name="$resolved"
@@ -31,86 +196,52 @@ update_one() {
   fi
 
   if [ -z "$repo" ]; then
-    RESULTS+=("${name}${SEP}-${SEP}-${SEP}✗${SEP}not a registered package or alias")
+    add_result "$name" "-" "-" "✗" "not a registered package or alias"
     echo "  ✗ $name — not a registered package or alias"
     return 1
   fi
 
   if [ ! -d "$repo" ]; then
-    RESULTS+=("${name}${SEP}-${SEP}-${SEP}✗${SEP}repo not found at $repo")
+    add_result "$name" "-" "-" "✗" "repo not found at $repo"
     echo "  ✗ $name — repo not found at $repo"
     return 1
   fi
 
-  # Skip frozen refs (detached HEAD = tag or commit pin)
-  if ! git -C "$repo" symbolic-ref HEAD &>/dev/null; then
-    local ref
-    ref=$(shiv_registry_ref "$name")
-    echo "  · $name  pinned to ${ref:-unknown ref} — skipping"
-    return 0
-  fi
+  mode=$(shiv_registry_ref_mode "$name")
+  ref=$(shiv_registry_ref "$name")
 
-  local branch before after output version dirty_marker
-  branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
-  before=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-
-  if output=$(git -C "$repo" pull --ff-only 2>&1); then
-    after=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-
-    # Check for dirty working tree
-    dirty_marker=""
-    if [ -n "$(git -C "$repo" status --porcelain 2>/dev/null | head -1)" ]; then
-      dirty_marker="*"
-    fi
-
-    # Use tag if available, otherwise short hash
-    local tag
-    tag=$(git -C "$repo" describe --tags --exact-match HEAD 2>/dev/null || echo "")
-    version="${tag:-$after}${dirty_marker}"
-
-    # Refresh shim only on successful pull
-    shiv_create_shim "$name" "$repo"
-
-    if [ "$before" = "$after" ]; then
-      RESULTS+=("${name}${SEP}${branch}${SEP}${version}${SEP}✓${SEP}already up to date")
-      echo "  ✓ $name — already up to date"
-    else
-      local count
-      count=$(git -C "$repo" rev-list --count "$before".."$after" 2>/dev/null || echo "?")
-      RESULTS+=("${name}${SEP}${branch}${SEP}${version}${SEP}✓${SEP}${before} → ${after} (${count} commits)")
-      echo "  ✓ $name — $before → $after ($count commits)"
-    fi
-  else
-    # Pull failed — figure out why, do NOT refresh shim
-    local reason
-    # Extract the meaningful error line (fatal/error), fall back to last non-empty line
-    reason=$(echo "$output" | grep -m1 -E '^(fatal|error):' || echo "$output" | grep -v '^$' | tail -1)
-
-    # Check for dirty working tree
-    dirty_marker=""
-    if [ -n "$(git -C "$repo" status --porcelain 2>/dev/null | head -1)" ]; then
-      dirty_marker="*"
-    fi
-
-    local tag
-    tag=$(git -C "$repo" describe --tags --exact-match HEAD 2>/dev/null || echo "")
-    version="${tag:-$before}${dirty_marker}"
-
-    RESULTS+=("${name}${SEP}${branch}${SEP}${version}${SEP}⚠${SEP}${reason}")
+  if [ -z "$mode" ]; then
+    branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+    version=$(package_version "$repo" "$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo unknown)")
+    reason="legacy install has no update intent; run 'shiv install ${name}@latest' or 'shiv install ${name}@main'"
+    add_result "$name" "$branch" "$version" "⚠" "$reason"
     echo "  ⚠ $name — $reason"
+    return 1
   fi
 
-  shiv_cache_tasks "$name" "$repo"
-  shiv_cache_task_map "$name" "$repo"
-
-  # Recreate alias symlinks
-  aliases=()
-  while IFS= read -r _alias; do
-    [ -n "$_alias" ] && aliases+=("$_alias")
-  done < <(shiv_registry_aliases "$name")
-  if [ ${#aliases[@]} -gt 0 ]; then
-    shiv_create_alias_symlinks "$name" "${aliases[@]}"
-  fi
+  case "$mode" in
+    release)
+      update_release "$name" "$repo" "$ref"
+      ;;
+    branch|local)
+      update_branch_like "$name" "$repo" "$mode" "$ref"
+      ;;
+    tag|commit)
+      branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+      version=$(package_version "$repo" "$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo unknown)")
+      add_result "$name" "$branch" "$version" "·" "pinned to ${ref:-unknown ref} — skipping"
+      echo "  · $name  pinned to ${ref:-unknown ref} — skipping"
+      return 0
+      ;;
+    *)
+      branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+      version=$(package_version "$repo" "$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo unknown)")
+      reason="unknown update intent '$mode'"
+      add_result "$name" "$branch" "$version" "⚠" "$reason"
+      echo "  ⚠ $name — $reason"
+      return 1
+      ;;
+  esac
 }
 
 if [ -n "$TARGET" ]; then
@@ -118,9 +249,9 @@ if [ -n "$TARGET" ]; then
   rc=0
   update_one "$TARGET" || rc=$?
 
-  # Single package — no summary table needed
+  # Single package — no summary table needed.
   if [ "${#RESULTS[@]}" -eq 1 ]; then
-    exit $rc
+    exit "$rc"
   fi
 else
   COUNT=$(jq 'length' "$SHIV_REGISTRY")
@@ -130,13 +261,13 @@ else
   fi
   echo "Updating $COUNT tool(s)..."
   echo ""
-  while IFS=$'\t' read -r name repo _ref; do
-    if ! update_one "$name"; then
-      :
-    fi
+  rc=0
+  while IFS=$'\t' read -r name _repo _ref; do
+    update_one "$name" || rc=1
   done < <(shiv_registry_entries)
 fi
 
 # Summary table (multi-package updates only)
 echo ""
 printf '%s\n' "${RESULTS[@]}" | gum table -s "$SEP" -c "PACKAGE,BRANCH,VERSION,STATUS,DETAIL" -p --border normal
+exit "$rc"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 281 passing](https://img.shields.io/badge/tests-281%20passing-brightgreen?style=flat)
+![tests: 283 passing](https://img.shields.io/badge/tests-283%20passing-brightgreen?style=flat)
 ![packages: 39](https://img.shields.io/badge/packages-39-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -134,7 +134,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — 281 tests across 13 suites.
+Tests use [BATS](https://github.com/bats-core/bats-core) — 283 tests across 13 suites.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 203 passing](https://img.shields.io/badge/tests-203%20passing-brightgreen?style=flat)
-![packages: 27](https://img.shields.io/badge/packages-27-blue?style=flat)
+![tests: 281 passing](https://img.shields.io/badge/tests-281%20passing-brightgreen?style=flat)
+![packages: 39](https://img.shields.io/badge/packages-39-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -47,7 +47,7 @@ When you run `shiv install foo`, shiv:
 4. Generates a shim at `~/.local/bin/foo`
 5. Registers the package in `~/.config/shiv/registry.json`
 
-The shim is a bash script that forwards commands to `mise -C <repo> run`. It exports a package-specific caller variable (for example, `SHIMMER_CALLER_PWD` for `shimmer`) so tools know where you invoked them, translates space-separated arguments to colon-joined task names (`agent message` → `agent:message`), and provides tab completions for all available tasks.
+The shim is a bash script that forwards commands to `mise -C <repo> run`. It exports a package-specific caller variable (for example, `SHIMMER_CALLER_PWD`) so tools know where you invoked them, translates space-separated arguments to colon-joined task names (`agent message` → `agent:message`), and provides tab completions for all available tasks.
 
 ## Install
 
@@ -93,6 +93,18 @@ shiv looks up packages from JSON source files in `~/.config/shiv/sources/`. The 
 }
 ```
 
+By default, package-index installs use the newest stable semver release tag. Use an explicit ref when you want branch tracking or an exact pin:
+
+```bash
+shiv install notes         # newest released semver tag
+shiv install notes@latest  # same as bare install
+shiv install notes@main    # track a branch explicitly
+shiv install notes@v0.8.4  # pin an exact tag
+shiv install notes@abc1234 # pin an exact commit
+```
+
+`shiv update` preserves that intent: release-channel installs advance to the newest release tag, branch installs pull their branch, and exact tag/commit pins stay fixed until you reinstall at another ref. Legacy installs without recorded intent are refused with guidance to choose `@latest` or `@main` explicitly.
+
 You can also install directly from a local path:
 
 ```bash
@@ -122,7 +134,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — 203 tests across 9 suites.
+Tests use [BATS](https://github.com/bats-core/bats-core) — 281 tests across 13 suites.
 
 <div align="center">
 

--- a/README.tsx
+++ b/README.tsx
@@ -155,6 +155,25 @@ shiv doctor`}</CodeBlock>
 }`}</CodeBlock>
 
       <Paragraph>
+        By default, package-index installs use the newest stable semver release tag.
+        Use an explicit ref when you want branch tracking or an exact pin:
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`shiv install notes         # newest released semver tag
+shiv install notes@latest  # same as bare install
+shiv install notes@main    # track a branch explicitly
+shiv install notes@v0.8.4  # pin an exact tag
+shiv install notes@abc1234 # pin an exact commit`}</CodeBlock>
+
+      <Paragraph>
+        <Code>shiv update</Code> preserves that intent: release-channel installs
+        advance to the newest release tag, branch installs pull their branch, and
+        exact tag/commit pins stay fixed until you reinstall at another ref.
+        Legacy installs without recorded intent are refused with guidance to
+        choose <Code>@latest</Code> or <Code>@main</Code> explicitly.
+      </Paragraph>
+
+      <Paragraph>
         You can also install directly from a local path:
       </Paragraph>
 

--- a/lib/registry.sh
+++ b/lib/registry.sh
@@ -56,9 +56,11 @@ shiv_register() {
   local tmp
   tmp=$(jq --arg n "$name" --arg p "$repo_dir" \
     --arg r "${SHIV_REF:-}" \
+    --arg m "${SHIV_REF_MODE:-}" \
     --argjson a "$aliases_json" \
     '.[$n] = ({"path": $p}
       + (if $r != "" then {"ref": $r} else {} end)
+      + (if $m != "" then {"refMode": $m} else {} end)
       + (if $a then {"aliases": $a} else {} end))' \
     "$SHIV_REGISTRY")
   echo "$tmp" > "$SHIV_REGISTRY"
@@ -89,6 +91,27 @@ shiv_registry_aliases() {
 shiv_registry_ref() {
   local name="$1"
   jq -r --arg n "$name" '.[$n].ref // empty' "$SHIV_REGISTRY"
+}
+
+# Get the update intent for a package (empty for legacy entries)
+shiv_registry_ref_mode() {
+  local name="$1"
+  jq -r --arg n "$name" '.[$n].refMode // empty' "$SHIV_REGISTRY"
+}
+
+# Set the current ref and update intent for an existing package.
+shiv_registry_set_ref() {
+  local name="$1" ref="$2" mode="$3"
+  shiv_init_registry
+  local tmp
+  tmp=$(jq --arg n "$name" --arg r "$ref" --arg m "$mode" \
+    '.[$n]
+      |= (. + (if $r != "" then {"ref": $r} else {} end)
+              + (if $m != "" then {"refMode": $m} else {} end))
+      | if $r == "" then .[$n] |= del(.ref) else . end
+      | if $m == "" then .[$n] |= del(.refMode) else . end' \
+    "$SHIV_REGISTRY")
+  echo "$tmp" > "$SHIV_REGISTRY"
 }
 
 # Set aliases for an existing package

--- a/lib/sources.sh
+++ b/lib/sources.sh
@@ -60,6 +60,54 @@ shiv_list_sources() {
   fi
 }
 
+# Sort stable semver-ish tags from stdin, preserving each original tag string.
+# Accepts v-prefixed or bare MAJOR.MINOR.PATCH tags (for example v1.2.3 or
+# 1.2.3). Prereleases and non-semver tags are ignored for now; semver range
+# support can broaden this later with a dedicated semver tool/library.
+shiv_semver_tag_sort() {
+  sed -n -E 's/^v?([0-9]+)\.([0-9]+)\.([0-9]+)$/\1 \2 \3 &/p' \
+    | awk '{printf "%09d.%09d.%09d %s\n", $1, $2, $3, $4}' \
+    | sort \
+    | awk '{print $2}'
+}
+
+# Print the latest stable semver-ish tag from stdin.
+shiv_latest_semver_tag() {
+  shiv_semver_tag_sort | tail -1
+}
+
+# Print the latest stable semver-ish tag available on a remote URL.
+# Returns:
+#   0 when a release tag is found (tag printed to stdout)
+#   1 when the remote is reachable but has no stable semver-ish tags
+#   2 when the remote cannot be queried
+shiv_latest_release_tag_from_url() {
+  local remote_url="$1"
+  local tags_output latest
+
+  if ! tags_output=$(git ls-remote --tags "$remote_url" 2>&1); then
+    echo "Error: failed to query release tags for $remote_url" >&2
+    printf '%s\n' "$tags_output" | sed 's/^/  /' >&2
+    return 2
+  fi
+
+  latest=$(printf '%s\n' "$tags_output" \
+    | sed '/\^{}$/d; s|.*refs/tags/||' \
+    | shiv_latest_semver_tag)
+
+  if [ -z "$latest" ]; then
+    return 1
+  fi
+
+  printf '%s\n' "$latest"
+}
+
+# Print the latest stable semver-ish tag for a GitHub repo slug.
+shiv_latest_release_tag() {
+  local gh_repo="$1"
+  shiv_latest_release_tag_from_url "https://github.com/${gh_repo}.git"
+}
+
 # Detect whether a ref is a tag, branch, or commit SHA
 # Usage: shiv_detect_ref_type <github-repo-slug> <ref>
 # Prints "tag", "branch", or "commit" to stdout; returns 1 if unknown

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
 "shiv:codebase" = "0.2.0"
+"shiv:readme" = "latest"
 bats = "1.13.0"
 gum = "0.17.0"
 jsonschema = "14.14.2"

--- a/registry.schema.json
+++ b/registry.schema.json
@@ -26,7 +26,12 @@
         },
         "ref": {
           "type": "string",
-          "description": "Git ref this package is pinned to (tag, branch, or commit SHA)."
+          "description": "Current Git ref for this package (release tag, branch, exact tag, or commit SHA)."
+        },
+        "refMode": {
+          "type": "string",
+          "enum": ["release", "branch", "tag", "commit", "local"],
+          "description": "Update intent for the ref: release channel, branch tracking, exact tag, exact commit, or local path."
         }
       },
       "required": ["path"],

--- a/test/install.bats
+++ b/test/install.bats
@@ -16,8 +16,10 @@ setup() {
   export SHIV_CONFIG_DIR="$TEST_HOME/.config/shiv"
   export SHIV_CACHE_DIR="$TEST_HOME/.cache/shiv"
   export SHIV_REGISTRY="$SHIV_CONFIG_DIR/registry.json"
+  export REMOTES_DIR="$TEST_HOME/remotes"
+  export GIT_CONFIG_GLOBAL="$TEST_HOME/gitconfig"
 
-  mkdir -p "$SHIV_BIN_DIR"
+  mkdir -p "$SHIV_BIN_DIR" "$REMOTES_DIR"
   shiv_init_registry
   setup_shiv_on_path
 
@@ -49,6 +51,41 @@ create_local_repo() {
   printf 'hello\tSay hello\n' > "$SHIV_CACHE_DIR/completions/$name.cache"
 
   echo "$repo_dir"
+}
+
+# Helper: create a bare remote package with optional release tags.
+create_remote_package() {
+  local name="$1"
+  shift
+  local work_dir="$TEST_HOME/work-$name"
+  local remote_dir="$REMOTES_DIR/$name.git"
+
+  mkdir -p "$work_dir"
+  git -C "$work_dir" init -q -b main
+  git -C "$work_dir" config user.email "test@test.com"
+  git -C "$work_dir" config user.name "Test"
+  touch "$work_dir/README.md"
+  git -C "$work_dir" add .
+  git -C "$work_dir" commit -q -m "init"
+
+  for tag in "$@"; do
+    echo "$tag" > "$work_dir/$tag.txt"
+    git -C "$work_dir" add .
+    git -C "$work_dir" commit -q -m "$tag"
+    git -C "$work_dir" tag -a "$tag" -m "$tag"
+  done
+
+  git clone -q --bare "$work_dir" "$remote_dir"
+  rm -rf "$work_dir"
+}
+
+# Helper: map a source-index GitHub slug to the local bare remote.
+configure_remote_source() {
+  local name="$1"
+  local sources="$TEST_HOME/sources.json"
+  printf '{"%s": "TestOrg/%s"}\n' "$name" "$name" > "$sources"
+  export SHIV_SOURCES="$sources"
+  git config --file "$GIT_CONFIG_GLOBAL" url."$REMOTES_DIR/".insteadOf "https://github.com/TestOrg/"
 }
 
 
@@ -115,6 +152,7 @@ MOCK
 
   run_install "myapp" "$repo_dir"
   [ -n "$(shiv_registry_path "myapp")" ]
+  [ "$(shiv_registry_ref_mode "myapp")" = "local" ]
 }
 
 @test "install: local path install runs mise trust and install" {
@@ -300,6 +338,65 @@ MOCK
 
   run bash -c "cd /tmp && '$SHIV_BIN_DIR/myapp' hello 2>&1"
   ! echo "$output" | grep -q "warning"
+}
+
+# ============================================================================
+# Package-index release and ref installs
+# ============================================================================
+
+@test "install: bare package install resolves to latest release tag" {
+  create_remote_package "alpha" "v1.0.0" "v1.2.0"
+  configure_remote_source "alpha"
+
+  run run_install "alpha"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "✓ Installed alpha@v1.2.0"
+  [ "$(shiv_registry_ref "alpha")" = "v1.2.0" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "release" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" describe --tags --exact-match HEAD)" = "v1.2.0" ]
+}
+
+@test "install: @latest resolves to latest release tag" {
+  create_remote_package "alpha" "v0.9.0" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run run_install "alpha@latest"
+  [ "$status" -eq 0 ]
+  [ "$(shiv_registry_ref "alpha")" = "v1.0.0" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "release" ]
+}
+
+@test "install: @main explicitly tracks the main branch" {
+  create_remote_package "alpha" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run run_install "alpha@main"
+  [ "$status" -eq 0 ]
+  [ "$(shiv_registry_ref "alpha")" = "main" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "branch" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" rev-parse --abbrev-ref HEAD)" = "main" ]
+}
+
+@test "install: exact tag is recorded as a pinned tag" {
+  create_remote_package "alpha" "v1.0.0" "v1.2.0"
+  configure_remote_source "alpha"
+
+  run run_install "alpha@v1.0.0"
+  [ "$status" -eq 0 ]
+  [ "$(shiv_registry_ref "alpha")" = "v1.0.0" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "tag" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" describe --tags --exact-match HEAD)" = "v1.0.0" ]
+}
+
+@test "install: package with no release tags tells user to choose a branch" {
+  create_remote_package "alpha"
+  configure_remote_source "alpha"
+
+  run run_install "alpha"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "No release tags found for alpha"
+  echo "$output" | grep -q "shiv install alpha@main"
+  [ ! -d "$SHIV_PACKAGES_DIR/alpha" ]
 }
 
 # ============================================================================

--- a/test/install.bats
+++ b/test/install.bats
@@ -88,6 +88,22 @@ configure_remote_source() {
   git config --file "$GIT_CONFIG_GLOBAL" url."$REMOTES_DIR/".insteadOf "https://github.com/TestOrg/"
 }
 
+# Helper: add a release tag to an existing bare remote package.
+add_remote_package_tag() {
+  local name="$1" tag="$2"
+  local remote_dir="$REMOTES_DIR/$name.git"
+  local tmp_dir="$TEST_HOME/tmp-$name-$tag"
+
+  git clone -q "$remote_dir" "$tmp_dir"
+  git -C "$tmp_dir" config user.email "test@test.com"
+  git -C "$tmp_dir" config user.name "Test"
+  echo "$tag" > "$tmp_dir/$tag.txt"
+  git -C "$tmp_dir" add .
+  git -C "$tmp_dir" commit -q -m "$tag"
+  git -C "$tmp_dir" tag -a "$tag" -m "$tag"
+  git -C "$tmp_dir" push -q origin main "$tag"
+  rm -rf "$tmp_dir"
+}
 
 # Helper: run shiv install through the mock shim
 run_install() {
@@ -369,6 +385,34 @@ MOCK
 @test "install: @main explicitly tracks the main branch" {
   create_remote_package "alpha" "v1.0.0"
   configure_remote_source "alpha"
+
+  run run_install "alpha@main"
+  [ "$status" -eq 0 ]
+  [ "$(shiv_registry_ref "alpha")" = "main" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "branch" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" rev-parse --abbrev-ref HEAD)" = "main" ]
+}
+
+@test "install: reinstalling release channel fetches newly available tags" {
+  create_remote_package "alpha" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run_install "alpha"
+  add_remote_package_tag "alpha" "v1.1.0"
+
+  run run_install "alpha"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "✓ Installed alpha@v1.1.0"
+  [ "$(shiv_registry_ref "alpha")" = "v1.1.0" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "release" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" describe --tags --exact-match HEAD)" = "v1.1.0" ]
+}
+
+@test "install: switching an existing release install to branch tracking fetches the branch" {
+  create_remote_package "alpha" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run_install "alpha"
 
   run run_install "alpha@main"
   [ "$status" -eq 0 ]

--- a/test/registry.bats
+++ b/test/registry.bats
@@ -226,6 +226,12 @@ setup() {
   jq -e '.foo.ref == "v1.0.0"' "$SHIV_REGISTRY"
 }
 
+@test "ref: register with ref mode stores update intent" {
+  SHIV_REF="v1.0.0" SHIV_REF_MODE="release" shiv_register "foo" "/path/to/foo"
+  jq -e '.foo.refMode == "release"' "$SHIV_REGISTRY"
+  [ "$(shiv_registry_ref_mode "foo")" = "release" ]
+}
+
 @test "ref: register without ref omits ref key" {
   shiv_register "foo" "/path/to/foo"
   run jq -e '.foo | has("ref")' "$SHIV_REGISTRY"
@@ -253,6 +259,20 @@ setup() {
   shiv_register "foo" "/path/to/foo"
   run jq -e '.foo | has("ref")' "$SHIV_REGISTRY"
   [ "$status" -ne 0 ]
+}
+
+@test "ref: re-register without ref mode clears previous intent" {
+  SHIV_REF="v1.0" SHIV_REF_MODE="release" shiv_register "foo" "/path/to/foo"
+  shiv_register "foo" "/path/to/foo"
+  run jq -e '.foo | has("refMode")' "$SHIV_REGISTRY"
+  [ "$status" -ne 0 ]
+}
+
+@test "ref: shiv_registry_set_ref updates ref and mode" {
+  shiv_register "foo" "/path/to/foo"
+  shiv_registry_set_ref "foo" "v2.0.0" "release"
+  [ "$(shiv_registry_ref "foo")" = "v2.0.0" ]
+  [ "$(shiv_registry_ref_mode "foo")" = "release" ]
 }
 
 # ============================================================================
@@ -333,6 +353,14 @@ setup() {
     skip "jsonschema not found"
   fi
   SHIV_REF="v1.0.0" shiv_register "foo" "/path/to/foo"
+  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+}
+
+@test "schema: registry with ref mode is valid" {
+  if ! command -v jsonschema &>/dev/null; then
+    skip "jsonschema not found"
+  fi
+  SHIV_REF="v1.0.0" SHIV_REF_MODE="release" shiv_register "foo" "/path/to/foo"
   jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
 }
 

--- a/test/update.bats
+++ b/test/update.bats
@@ -62,6 +62,33 @@ push_remote_commit() {
   rm -rf "$tmp_dir"
 }
 
+# Helper: push a release tag to the remote.
+push_remote_tag() {
+  local name="$1" tag="$2"
+  local bare_dir="$TEST_HOME/remotes/$name.git"
+  local tmp_dir="$TEST_HOME/tmp-tag"
+
+  git clone -q "$bare_dir" "$tmp_dir"
+  git -C "$tmp_dir" config user.email "test@test.com"
+  git -C "$tmp_dir" config user.name "Test"
+  echo "$tag" > "$tmp_dir/$tag.txt"
+  git -C "$tmp_dir" add .
+  git -C "$tmp_dir" commit -q -m "$tag"
+  git -C "$tmp_dir" tag -a "$tag" -m "$tag"
+  git -C "$tmp_dir" push -q origin main "$tag"
+  rm -rf "$tmp_dir"
+}
+
+# Helper: register a package as an explicit branch-tracking install.
+register_branch_package() {
+  local name="$1"
+  shift
+  local repo="$SHIV_PACKAGES_DIR/$name"
+  local branch
+  branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD)
+  SHIV_REF="$branch" SHIV_REF_MODE="branch" shiv_register "$name" "$repo" "$@"
+}
+
 # Helper: run shiv update through the mock shim
 run_update() {
   local name="${1:-}"
@@ -110,7 +137,7 @@ extract_column() {
 
 @test "update: up-to-date package shows ✓" {
   create_test_repo_with_remote "alpha"
-  shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+  register_branch_package "alpha"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
 
   run run_update "alpha"
@@ -123,9 +150,56 @@ extract_column() {
 # Successful update (with new commits)
 # ============================================================================
 
-@test "update: new commits shows commit range" {
+@test "update: release channel advances to newest release tag" {
+  create_test_repo_with_remote "alpha"
+  push_remote_tag "alpha" "v1.0.0"
+  git -C "$SHIV_PACKAGES_DIR/alpha" fetch -q --tags origin
+  git -C "$SHIV_PACKAGES_DIR/alpha" checkout -q "v1.0.0"
+  SHIV_REF="v1.0.0" SHIV_REF_MODE="release" shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+  shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
+
+  push_remote_tag "alpha" "v1.1.0"
+
+  run run_update "alpha"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "v1.0.0 → v1.1.0"
+  [ "$(shiv_registry_ref "alpha")" = "v1.1.0" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "release" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" describe --tags --exact-match HEAD)" = "v1.1.0" ]
+}
+
+@test "update: exact tag pin stays fixed when newer release exists" {
+  create_test_repo_with_remote "alpha"
+  push_remote_tag "alpha" "v1.0.0"
+  git -C "$SHIV_PACKAGES_DIR/alpha" fetch -q --tags origin
+  git -C "$SHIV_PACKAGES_DIR/alpha" checkout -q "v1.0.0"
+  SHIV_REF="v1.0.0" SHIV_REF_MODE="tag" shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+  shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
+
+  push_remote_tag "alpha" "v1.1.0"
+
+  run run_update "alpha"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "pinned to v1.0.0"
+  [ "$(shiv_registry_ref "alpha")" = "v1.0.0" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "tag" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" describe --tags --exact-match HEAD)" = "v1.0.0" ]
+}
+
+@test "update: legacy package without update intent fails with reinstall guidance" {
   create_test_repo_with_remote "alpha"
   shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+
+  run run_update "alpha"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "legacy install has no update intent"
+  echo "$output" | grep -q "shiv install alpha@latest"
+  echo "$output" | grep -q "shiv install alpha@main"
+}
+
+@test "update: new commits shows commit range" {
+  create_test_repo_with_remote "alpha"
+  register_branch_package "alpha"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
 
   push_remote_commit "alpha"
@@ -143,7 +217,7 @@ extract_column() {
 
 @test "update: diverged repo shows ⚠ with reason" {
   create_test_repo_with_remote "alpha"
-  shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+  register_branch_package "alpha"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
 
   # Push a commit to remote
@@ -163,7 +237,7 @@ extract_column() {
 
 @test "update: pull failure does not refresh shim" {
   create_test_repo_with_remote "alpha"
-  shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+  register_branch_package "alpha"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
 
   # Record shim content hash
@@ -192,8 +266,8 @@ extract_column() {
 @test "update: multi-package shows summary table" {
   create_test_repo_with_remote "alpha"
   create_test_repo_with_remote "bravo"
-  shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
-  shiv_register "bravo" "$SHIV_PACKAGES_DIR/bravo"
+  register_branch_package "alpha"
+  register_branch_package "bravo"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
   shiv_create_shim "bravo" "$SHIV_PACKAGES_DIR/bravo"
 
@@ -206,7 +280,7 @@ extract_column() {
 
 @test "update: single package skips summary table" {
   create_test_repo_with_remote "alpha"
-  shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+  register_branch_package "alpha"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
 
   run run_update "alpha"
@@ -221,12 +295,12 @@ extract_column() {
 
 @test "update: shows branch in summary table" {
   create_test_repo_with_remote "alpha" "develop"
-  shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+  register_branch_package "alpha"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
 
   # Need a second package to trigger summary table
   create_test_repo_with_remote "bravo"
-  shiv_register "bravo" "$SHIV_PACKAGES_DIR/bravo"
+  register_branch_package "bravo"
   shiv_create_shim "bravo" "$SHIV_PACKAGES_DIR/bravo"
 
   run run_update
@@ -236,7 +310,7 @@ extract_column() {
 
 @test "update: shows dirty marker in summary table" {
   create_test_repo_with_remote "alpha"
-  shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha"
+  register_branch_package "alpha"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
 
   # Make it dirty
@@ -244,7 +318,7 @@ extract_column() {
 
   # Need a second package to trigger summary table
   create_test_repo_with_remote "bravo"
-  shiv_register "bravo" "$SHIV_PACKAGES_DIR/bravo"
+  register_branch_package "bravo"
   shiv_create_shim "bravo" "$SHIV_PACKAGES_DIR/bravo"
 
   run run_update
@@ -259,7 +333,7 @@ extract_column() {
 
 @test "update: resolves alias to package name" {
   create_test_repo_with_remote "alpha"
-  shiv_register "alpha" "$SHIV_PACKAGES_DIR/alpha" "a"
+  register_branch_package "alpha" "a"
   shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
 
   run run_update "a"


### PR DESCRIPTION
## Summary

Closes #122.

- Make `shiv install <pkg>` and `<pkg>@latest` resolve the newest stable semver release tag instead of cloning the default branch.
- Record update intent in the registry as `refMode` (`release`, `branch`, `tag`, `commit`, `local`) so `shiv update` can preserve release-vs-branch-vs-pin semantics.
- Make `shiv update` advance release-channel installs to the newest release tag, pull branch/local installs, skip exact tag/commit pins, and refuse legacy entries that have no recorded update intent.
- Fix reinstalling existing release/tag installs so narrow tag clones fetch the newly resolved ref before checkout; branch switches fetch/configure the requested remote branch and refuse to reset local branch commits.
- Declare the `readme` tool for this README.tsx repo, document the install/update contract, and regenerate README metadata.

## Verification

- `mise run test` — 257/257 default tests
- `mise run test completions` — 28/28 completions tests
- `mise run test install` — 32/32 install tests
- `mise run test install registry update` — 93/93 targeted tests after adding `shiv:readme`
- targeted reinstall regressions: release-channel new tag, release → branch, clean local branch reuse, local-ahead branch refusal
- `bash -n .mise/tasks/install .mise/tasks/update lib/registry.sh lib/sources.sh`
- `mise run registry:validate`
- `git diff --check`
- `mise install && mise exec -- readme build --check`
- codebase 0.2.0 lints individually with absolute shiv target: `lint:mise-settings`, `lint:bats-test-helper`, `lint:bats-test-task`, `lint:mcr-scope`, `lint:or-true`, `lint:shellcheck`, `lint:gum-table`

## Notes

- Absorbed quick's fix-it #124, with an added non-destructive local-ahead branch guard. k7r2's overlapping #125 was closed as superseded.
- `mise exec -- codebase lint` is unavailable because shiv pins codebase 0.2.0, which predates the aggregate `lint` task; I ran the declared lint subtasks individually instead.
