### PR TITLE
Fix reinstall ref switching for shallow release clones

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -95,11 +95,30 @@ else
     CURRENT_BRANCH=$(git -C "$TOOL_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
     if [ "$REF" != "$EXISTING_REF" ] || [ "$REF_MODE" != "$EXISTING_MODE" ]; then
       echo "  Ref changed (${EXISTING_MODE:-legacy}:${EXISTING_REF:-unknown} → ${REF_MODE}:${REF}), switching..."
-      git -C "$TOOL_PATH" fetch origin 2>&1 | sed 's/^/  /'
-      git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+      case "$REF_MODE" in
+        release|tag)
+          git -C "$TOOL_PATH" fetch --tags origin 2>&1 | sed 's/^/  /'
+          ;;
+        branch)
+          git -C "$TOOL_PATH" config --add remote.origin.fetch "+refs/heads/$REF:refs/remotes/origin/$REF"
+          git -C "$TOOL_PATH" fetch origin "+refs/heads/$REF:refs/remotes/origin/$REF" 2>&1 | sed 's/^/  /'
+          ;;
+        commit)
+          git -C "$TOOL_PATH" fetch --depth 1 origin "$REF" 2>&1 | sed 's/^/  /'
+          ;;
+      esac
+      if [ "$REF_MODE" = "branch" ]; then
+        git -C "$TOOL_PATH" checkout -B "$REF" "origin/$REF" 2>&1 | sed 's/^/  /'
+        git -C "$TOOL_PATH" branch --set-upstream-to="origin/$REF" "$REF" 2>&1 | sed 's/^/  /'
+      else
+        git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+      fi
     elif [ "$REF_MODE" = "branch" ] && [ "$REF" != "$CURRENT_BRANCH" ]; then
       echo "  Branch changed (${CURRENT_BRANCH:-detached} → ${REF}), switching..."
-      git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+      git -C "$TOOL_PATH" config --add remote.origin.fetch "+refs/heads/$REF:refs/remotes/origin/$REF"
+      git -C "$TOOL_PATH" fetch origin "+refs/heads/$REF:refs/remotes/origin/$REF" 2>&1 | sed 's/^/  /'
+      git -C "$TOOL_PATH" checkout -B "$REF" "origin/$REF" 2>&1 | sed 's/^/  /'
+      git -C "$TOOL_PATH" branch --set-upstream-to="origin/$REF" "$REF" 2>&1 | sed 's/^/  /'
     fi
   fi
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 281 passing](https://img.shields.io/badge/tests-281%20passing-brightgreen?style=flat)
+![tests: 283 passing](https://img.shields.io/badge/tests-283%20passing-brightgreen?style=flat)
 ![packages: 39](https://img.shields.io/badge/packages-39-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -134,7 +134,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — 281 tests across 13 suites.
+Tests use [BATS](https://github.com/bats-core/bats-core) — 283 tests across 13 suites.
 
 <div align="center">
 

--- a/test/install.bats
+++ b/test/install.bats
@@ -88,6 +88,22 @@ configure_remote_source() {
   git config --file "$GIT_CONFIG_GLOBAL" url."$REMOTES_DIR/".insteadOf "https://github.com/TestOrg/"
 }
 
+# Helper: add a release tag to an existing bare remote package.
+add_remote_package_tag() {
+  local name="$1" tag="$2"
+  local remote_dir="$REMOTES_DIR/$name.git"
+  local tmp_dir="$TEST_HOME/tmp-$name-$tag"
+
+  git clone -q "$remote_dir" "$tmp_dir"
+  git -C "$tmp_dir" config user.email "test@test.com"
+  git -C "$tmp_dir" config user.name "Test"
+  echo "$tag" > "$tmp_dir/$tag.txt"
+  git -C "$tmp_dir" add .
+  git -C "$tmp_dir" commit -q -m "$tag"
+  git -C "$tmp_dir" tag -a "$tag" -m "$tag"
+  git -C "$tmp_dir" push -q origin main "$tag"
+  rm -rf "$tmp_dir"
+}
 
 # Helper: run shiv install through the mock shim
 run_install() {
@@ -369,6 +385,34 @@ MOCK
 @test "install: @main explicitly tracks the main branch" {
   create_remote_package "alpha" "v1.0.0"
   configure_remote_source "alpha"
+
+  run run_install "alpha@main"
+  [ "$status" -eq 0 ]
+  [ "$(shiv_registry_ref "alpha")" = "main" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "branch" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" rev-parse --abbrev-ref HEAD)" = "main" ]
+}
+
+@test "install: reinstalling release channel fetches newly available tags" {
+  create_remote_package "alpha" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run_install "alpha"
+  add_remote_package_tag "alpha" "v1.1.0"
+
+  run run_install "alpha"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "✓ Installed alpha@v1.1.0"
+  [ "$(shiv_registry_ref "alpha")" = "v1.1.0" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "release" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" describe --tags --exact-match HEAD)" = "v1.1.0" ]
+}
+
+@test "install: switching an existing release install to branch tracking fetches the branch" {
+  create_remote_package "alpha" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run_install "alpha"
 
   run run_install "alpha@main"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes the reinstall path for existing package directories that were cloned from release/tag refs with a narrow fetch refspec:

- fetch tags before switching release/tag refs
- fetch and configure the requested branch ref before switching to branch tracking
- add regressions for release-channel reinstall after a new tag and switching a release install to `@main`

## Verification

- `mise run test` — 255/255 default tests
- `mise run test completions` — 28/28 completions tests
- `bash -n .mise/tasks/install .mise/tasks/update lib/registry.sh lib/sources.sh`
- `git diff --check`
- `mise exec -- codebase lint:shellcheck .`

Note: `readme` is not available in this runner (`readme: command not found`; `mise exec -- readme` also unavailable), so I updated the generated README count manually from the BATS test count.
