### PR TITLE
Fix release reinstall fetches

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -95,7 +95,17 @@ else
     CURRENT_BRANCH=$(git -C "$TOOL_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
     if [ "$REF" != "$EXISTING_REF" ] || [ "$REF_MODE" != "$EXISTING_MODE" ]; then
       echo "  Ref changed (${EXISTING_MODE:-legacy}:${EXISTING_REF:-unknown} → ${REF_MODE}:${REF}), switching..."
-      git -C "$TOOL_PATH" fetch origin 2>&1 | sed 's/^/  /'
+      case "$REF_TYPE" in
+        commit)
+          git -C "$TOOL_PATH" fetch --depth 1 origin "$REF" 2>&1 | sed 's/^/  /'
+          ;;
+        tag)
+          git -C "$TOOL_PATH" fetch --tags origin 2>&1 | sed 's/^/  /'
+          ;;
+        branch)
+          git -C "$TOOL_PATH" fetch origin "$REF" 2>&1 | sed 's/^/  /'
+          ;;
+      esac
       git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
     elif [ "$REF_MODE" = "branch" ] && [ "$REF" != "$CURRENT_BRANCH" ]; then
       echo "  Branch changed (${CURRENT_BRANCH:-detached} → ${REF}), switching..."

--- a/test/install.bats
+++ b/test/install.bats
@@ -88,6 +88,23 @@ configure_remote_source() {
   git config --file "$GIT_CONFIG_GLOBAL" url."$REMOTES_DIR/".insteadOf "https://github.com/TestOrg/"
 }
 
+# Helper: add a release tag to an existing bare remote package.
+push_remote_release() {
+  local name="$1" tag="$2"
+  local work_dir="$TEST_HOME/update-$name"
+  local remote_dir="$REMOTES_DIR/$name.git"
+
+  git clone -q "$remote_dir" "$work_dir"
+  git -C "$work_dir" config user.email "test@test.com"
+  git -C "$work_dir" config user.name "Test"
+  echo "$tag" > "$work_dir/$tag.txt"
+  git -C "$work_dir" add .
+  git -C "$work_dir" commit -q -m "$tag"
+  git -C "$work_dir" tag -a "$tag" -m "$tag"
+  git -C "$work_dir" push -q origin main "$tag"
+  rm -rf "$work_dir"
+}
+
 
 # Helper: run shiv install through the mock shim
 run_install() {
@@ -364,6 +381,23 @@ MOCK
   [ "$status" -eq 0 ]
   [ "$(shiv_registry_ref "alpha")" = "v1.0.0" ]
   [ "$(shiv_registry_ref_mode "alpha")" = "release" ]
+}
+
+@test "install: reinstalling release channel fetches newly released tags" {
+  create_remote_package "alpha" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run run_install "alpha"
+  [ "$status" -eq 0 ]
+  [ "$(shiv_registry_ref "alpha")" = "v1.0.0" ]
+
+  push_remote_release "alpha" "v1.1.0"
+
+  run run_install "alpha"
+  [ "$status" -eq 0 ]
+  [ "$(shiv_registry_ref "alpha")" = "v1.1.0" ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "release" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" describe --tags --exact-match HEAD)" = "v1.1.0" ]
 }
 
 @test "install: @main explicitly tracks the main branch" {


### PR DESCRIPTION
## Summary

- fetch tags when switching an existing install to a newly resolved release/tag ref
- fetch exact commit refs explicitly when reinstalling to a different commit
- add regression coverage for reinstalling a release-channel package after a newer release appears

## Verification

- `mise run test`
- `mise run test completions`
- `bash -n .mise/tasks/install .mise/tasks/update lib/registry.sh lib/sources.sh`
- `mise run registry:validate`
- `git diff --check`