### PR TITLE
chore: bump codebase lint dependency

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ experimental = true
 shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
-"shiv:codebase" = "0.2.0"
+"shiv:codebase" = "0.3"
 "shiv:readme" = "latest"
 bats = "1.13.0"
 gum = "0.17.0"


### PR DESCRIPTION
## Summary

Bump shiv's `shiv:codebase` development dependency from exact `0.2.0` to the `0.3` minor stream.

## Why

`codebase v0.3.0` added the aggregate `codebase lint` entrypoint. During the `shiv v0.3.0` release, `mise exec -- codebase lint .` failed because shiv was still pinned to `codebase v0.2.0`.

Using `0.3` lets shiv receive compatible `0.3.x` codebase patch fixes without another exact-pin bump/release cascade. This follows mise's partial-version behavior, analogous to `python = "3"` resolving to latest 3.x. Mise also has explicit `prefix:<PREFIX>` for ambiguous cases.

This addresses the root cause behind KnickKnackLabs/codebase#41 from the consumer side.

## Validation

- `mise install`
- `mise where shiv:codebase` → `.../shiv-codebase/0.3.0`
- `mise exec -- codebase --help` includes aggregate `lint`
- `mise exec -- codebase lint .` — 7/7 configured rules passed
- `mise run test` — 266/266 passed
- `mise run test completions` — 28/28 passed
- `git pre-commit` — OK
