### PR TITLE
feat: add bin/shiv bootstrap entry point

### DIFF
--- a/bin/shiv
+++ b/bin/shiv
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Bootstrap entry point — works without mise installed.
+set -eo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v mise >/dev/null 2>&1; then
+  echo "shiv: mise not found — installing..." >&2
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "shiv: curl required. Install it and retry." >&2
+    exit 1
+  fi
+  curl -fsSL https://mise.jdx.dev/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  if ! command -v mise >/dev/null 2>&1; then
+    echo "shiv: mise install failed. See: https://mise.jdx.dev" >&2
+    exit 1
+  fi
+fi
+
+mise trust -q "$REPO" 2>/dev/null || true
+exec mise -C "$REPO" run "$@"

--- a/test/bootstrap.bats
+++ b/test/bootstrap.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# bin/shiv bootstrap wrapper tests
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+
+setup() {
+  MOCK_BIN="$BATS_TEST_TMPDIR/mock-bin"
+  mkdir -p "$MOCK_BIN"
+}
+
+# Fake mise: records every invocation to mise-calls, exits 0.
+_mock_mise() {
+  cat > "$MOCK_BIN/mise" <<MOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$BATS_TEST_TMPDIR/mise-calls"
+MOCK
+  chmod +x "$MOCK_BIN/mise"
+}
+
+# A PATH containing only dirname — no mise, no curl.
+_minimal_path() {
+  local mini="$BATS_TEST_TMPDIR/mini-bin"
+  mkdir -p "$mini"
+  ln -sf "$(command -v dirname)" "$mini/dirname"
+  echo "$mini"
+}
+
+@test "bin/shiv: delegates to mise -C <repo-root> run <args> when mise is present" {
+  _mock_mise
+  local expected
+  expected="$(cd "$REPO_DIR" && pwd)"
+  run env PATH="$MOCK_BIN:$PATH" bash "$REPO_DIR/bin/shiv" install foo --flag
+  [ "$status" -eq 0 ]
+  grep -qF -- "-C $expected run install foo --flag" "$BATS_TEST_TMPDIR/mise-calls"
+}
+
+@test "bin/shiv: resolves repo root from BASH_SOURCE not from caller CWD" {
+  _mock_mise
+  local expected
+  expected="$(cd "$REPO_DIR" && pwd)"
+  run bash -c "cd '$BATS_TEST_TMPDIR' && PATH='$MOCK_BIN:$PATH' bash '$REPO_DIR/bin/shiv' sometask"
+  [ "$status" -eq 0 ]
+  grep -qF -- "-C $expected run sometask" "$BATS_TEST_TMPDIR/mise-calls"
+}
+
+@test "bin/shiv: exits 1 with curl-required message when mise and curl are both absent" {
+  local mini bash_bin
+  mini="$(_minimal_path)"
+  bash_bin="$(command -v bash)"
+  run bash -c "PATH='$mini' '$bash_bin' '$REPO_DIR/bin/shiv' sometask 2>&1"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"curl required"* ]]
+}


### PR DESCRIPTION
Closes #1.

## Summary

- Adds `bin/shiv` — a plain-bash wrapper (~22 lines, no deps beyond bash + curl) that installs mise if missing, then delegates all invocations to `mise -C <repo-root> run "$@"`
- Adds `test/bootstrap.bats` with three BATS tests covering the wrapper

## How it works

```
┌─────────────────────────────────┐
│  Full shiv (mise tasks)         │
├─────────────────────────────────┤
│  bin/shiv bootstrapper (bash)   │  ← this PR
└─────────────────────────────────┘
```

`bin/shiv` self-locates the repo root via `BASH_SOURCE[0]` (works regardless of CWD), runs `mise trust -q` to suppress the first-clone prompt, then `exec mise -C "$REPO" run "$@"`. On machines without mise it installs it via the official installer, then delegates as normal. Does not touch `install.sh`.

## Tests

| Test | Covers |
|---|---|
| delegates to `mise -C <repo-root> run <args>` | correct invocation format |
| resolves repo root from BASH_SOURCE not caller CWD | `BASH_SOURCE[0]` path resolution |
| exits 1 with curl-required message when both absent | error branch reachability + message |

The `mise absent + curl present → install` branch requires a containerized environment to test cleanly (acknowledged in #1); left as a documented manual case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)