### PR TITLE
feat: add shiv seed — generate self-installable shell task

### DIFF
--- a/.mise/tasks/seed
+++ b/.mise/tasks/seed
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#MISE description="Generate a self-installable shell task in a target repo"
+#USAGE arg "<name>" help="Tool name to seed into the current repo"
+set -euo pipefail
+
+REPO_DIR="$(cd "$MISE_CONFIG_ROOT" && pwd)"
+source "$REPO_DIR/lib/shim.sh"
+
+NAME="${1:?shiv seed: <name> required}"
+TARGET="$PWD"
+TASKS_DIR="$TARGET/.mise/tasks"
+CALLER_PWD_VAR="$(shiv_caller_pwd_var_name "$NAME")"
+
+if [ "$TARGET" = "$REPO_DIR" ]; then
+  echo "shiv seed: cannot seed into shiv itself" >&2
+  exit 1
+fi
+
+if [ -f "$TASKS_DIR/shell" ]; then
+  echo "shiv seed: $TASKS_DIR/shell already exists — remove it first to re-seed" >&2
+  exit 1
+fi
+
+mkdir -p "$TASKS_DIR"
+
+cat > "$TASKS_DIR/shell" << SEED
+#!/usr/bin/env bash
+#MISE description="Output shell configuration for eval"
+set -eo pipefail
+
+_REPO="\$MISE_CONFIG_ROOT"
+_NAME="$NAME"
+_BIN_DIR="\${HOME}/.local/bin"
+_SHIM="\$_BIN_DIR/\$_NAME"
+
+mkdir -p "\$_BIN_DIR"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# managed by shiv\n'
+  printf 'REPO="%s"\n' "\$_REPO"
+  printf '${CALLER_PWD_VAR}="\$PWD"\n'
+  printf 'exec mise -C "\$REPO" run "\$@"\n'
+} > "\$_SHIM"
+chmod +x "\$_SHIM"
+
+if [[ ":\${PATH}:" != *":\$_BIN_DIR:"* ]]; then
+  printf "export PATH='%s'\n" "\$_BIN_DIR:\${PATH}"
+fi
+SEED
+
+chmod +x "$TASKS_DIR/shell"
+echo "shiv seed: created $TASKS_DIR/shell for '$NAME'" >&2
+echo "shiv seed: to install, run: eval \"\$(mise -C $TARGET run -q shell)\"" >&2

--- a/test/seed.bats
+++ b/test/seed.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# shiv seed test suite
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+
+setup() {
+  TARGET="$BATS_TEST_TMPDIR/my-tool"
+  MOCK_HOME="$BATS_TEST_TMPDIR/home"
+  mkdir -p "$TARGET" "$MOCK_HOME"
+}
+
+# Run the seed task with TARGET as CWD
+_seed() {
+  run bash -c "cd '$TARGET' && MISE_CONFIG_ROOT='$REPO_DIR' bash '$REPO_DIR/.mise/tasks/seed' '$1' 2>&1"
+}
+
+# Run the generated shell task with TARGET as the repo root
+_run_shell() {
+  run env \
+    MISE_CONFIG_ROOT="$TARGET" \
+    HOME="$MOCK_HOME" \
+    bash "$TARGET/.mise/tasks/shell"
+}
+
+@test "seed: creates .mise/tasks/shell in the target repo" {
+  _seed "my-tool"
+  [ "$status" -eq 0 ]
+  [ -f "$TARGET/.mise/tasks/shell" ]
+}
+
+@test "seed: generated shell task is executable" {
+  _seed "my-tool"
+  [ -x "$TARGET/.mise/tasks/shell" ]
+}
+
+@test "seed: generated shell task bakes the tool name into _NAME" {
+  _seed "my-tool"
+  grep -q '_NAME="my-tool"' "$TARGET/.mise/tasks/shell"
+}
+
+@test "seed: generated shell task uses MISE_CONFIG_ROOT as repo path" {
+  _seed "my-tool"
+  grep -q '_REPO="\$MISE_CONFIG_ROOT"' "$TARGET/.mise/tasks/shell"
+}
+
+@test "seed: generated shell task creates shim at expected path" {
+  _seed "my-tool"
+  _run_shell
+  [ -f "$MOCK_HOME/.local/bin/my-tool" ]
+}
+
+@test "seed: generated shell task makes shim executable" {
+  _seed "my-tool"
+  _run_shell
+  [ -x "$MOCK_HOME/.local/bin/my-tool" ]
+}
+
+@test "seed: shim has repo path baked in" {
+  _seed "my-tool"
+  _run_shell
+  grep -q "REPO=\"$TARGET\"" "$MOCK_HOME/.local/bin/my-tool"
+}
+
+@test "seed: shim delegates to mise -C REPO run" {
+  _seed "my-tool"
+  _run_shell
+  grep -q 'exec mise -C "\$REPO" run "\$@"' "$MOCK_HOME/.local/bin/my-tool"
+}
+
+@test "seed: shim sets package-specific caller PWD var" {
+  _seed "my-tool"
+  _run_shell
+  grep -q 'MY_TOOL_CALLER_PWD="\$PWD"' "$MOCK_HOME/.local/bin/my-tool"
+}
+
+@test "seed: generated shell task emits PATH export when bin dir is absent" {
+  _seed "my-tool"
+  run env \
+    MISE_CONFIG_ROOT="$TARGET" \
+    HOME="$MOCK_HOME" \
+    PATH="/bin:/usr/bin" \
+    bash "$TARGET/.mise/tasks/shell"
+  [[ "$output" == *"export PATH="* ]]
+  [[ "$output" == *"$MOCK_HOME/.local/bin"* ]]
+}
+
+@test "seed: generated shell task emits no PATH export when bin dir already present" {
+  _seed "my-tool"
+  run env \
+    MISE_CONFIG_ROOT="$TARGET" \
+    HOME="$MOCK_HOME" \
+    PATH="$MOCK_HOME/.local/bin:/bin:/usr/bin" \
+    bash "$TARGET/.mise/tasks/shell"
+  [[ "$output" != *"export PATH="* ]]
+}
+
+@test "seed: errors if shell task already exists" {
+  _seed "my-tool"
+  _seed "my-tool"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists"* ]]
+}
+
+@test "seed: errors when targeting shiv itself" {
+  local resolved
+  resolved="$(cd "$REPO_DIR" && pwd)"
+  run bash -c "cd '$resolved' && MISE_CONFIG_ROOT='$resolved' bash '$REPO_DIR/.mise/tasks/seed' 'shiv' 2>&1"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot seed into shiv itself"* ]]
+}
+
+@test "seed: caller PWD var name follows package naming convention" {
+  TARGET="$BATS_TEST_TMPDIR/my-cool-pkg"
+  mkdir -p "$TARGET"
+  run bash -c "cd '$TARGET' && MISE_CONFIG_ROOT='$REPO_DIR' bash '$REPO_DIR/.mise/tasks/seed' 'my-cool-pkg' 2>&1"
+  [ "$status" -eq 0 ]
+  grep -q 'MY_COOL_PKG_CALLER_PWD' "$TARGET/.mise/tasks/shell"
+}


### PR DESCRIPTION
Closes #2.

## Summary

- Adds `.mise/tasks/seed` — takes `<name>`, generates `.mise/tasks/shell` in the current repo
- The generated `shell` task is **fully self-contained**: no runtime dependency on shiv
- Running `eval "$(mise -C <repo> run -q shell)"` creates a shim at `~/.local/bin/<name>` with the repo path baked in, then emits a `PATH` export if needed
- Adds `test/seed.bats` — 14 tests covering the task and the generated output

## How it works

```
shiv seed my-tool          # run once in the target repo
↓
.mise/tasks/shell          # generated, self-contained

eval "$(mise -C ~/my-tool run -q shell)"   # user runs this
↓
~/.local/bin/my-tool       # shim created, PATH exported
```

The generated shim:
```bash
#!/usr/bin/env bash
# managed by shiv
REPO="/path/to/my-tool"       # baked in at shell-task runtime
MY_TOOL_CALLER_PWD="$PWD"     # expands at shim runtime
exec mise -C "$REPO" run "$@"
```

## Design decisions

- **`$MISE_CONFIG_ROOT` as runtime anchor** — the generated `shell` task uses `$MISE_CONFIG_ROOT` (set by mise when the user runs the task) to bake the repo path into the shim. Path is always correct regardless of where `shiv seed` was invoked.
- **No `mise.toml` generation** — left to the user; seed only writes the task.
- **No registry entry** — seed is lite-tier. Users can follow up with `shiv install` if they want `shiv list`/`shiv doctor` coverage.
- **Self-targeting guard** — seeding into shiv itself is blocked.

## Relation to PR #132

PR #132 (`bin/shiv`) established the reference pattern: a plain-bash entry point that self-locates the repo and delegates to `mise run`. This PR generalises it: instead of a repo hardcoding `bin/shiv`, `shiv seed` generates the equivalent `shell` task for any repo.

## Tests (14)

Covers: task creation, executability, generated content correctness (name, MISE_CONFIG_ROOT usage, CALLER_PWD var naming convention), shim creation and content, PATH export behaviour (emitted/suppressed), error on re-seed, self-targeting guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)