### PR TITLE
fix(install): suppress detached-HEAD advice for release/tag/commit installs (#126)

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -147,7 +147,9 @@ else
       if [ "$REF_MODE" = "branch" ]; then
         checkout_branch_ref "$REF"
       else
-        git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+        # Release/tag/commit checkouts are intentionally detached; mute Git's
+        # detached-HEAD advisory while still surfacing real checkout errors.
+        git -C "$TOOL_PATH" -c advice.detachedHead=false checkout "$REF" 2>&1 | sed 's/^/  /'
       fi
     elif [ "$REF_MODE" = "branch" ] && [ "$REF" != "$CURRENT_BRANCH" ]; then
       echo "  Branch changed (${CURRENT_BRANCH:-detached} → ${REF}), switching..."
@@ -177,12 +179,14 @@ else
         gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --branch "$REF" --single-branch "$CLONE_URL" "$TOOL_PATH"
         ;;
       tag)
-        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --branch "$REF" --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"
+        # Cloning a tag lands in detached HEAD by design — suppress the advisory.
+        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git -c advice.detachedHead=false clone --branch "$REF" --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"
         ;;
       commit)
         gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"
         git -C "$TOOL_PATH" fetch --depth 1 origin "$REF" 2>&1 | sed 's/^/  /'
-        git -C "$TOOL_PATH" checkout "$REF" 2>&1 | sed 's/^/  /'
+        # Commit checkout is intentionally detached — suppress the advisory.
+        git -C "$TOOL_PATH" -c advice.detachedHead=false checkout "$REF" 2>&1 | sed 's/^/  /'
         ;;
     esac
   fi

--- a/test/install.bats
+++ b/test/install.bats
@@ -435,6 +435,41 @@ MOCK
   [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" rev-parse --abbrev-ref HEAD)" = "main" ]
 }
 
+@test "install: release install does not print detached-HEAD advice" {
+  create_remote_package "alpha" "v1.0.0" "v1.2.0"
+  configure_remote_source "alpha"
+
+  run run_install "alpha"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q "detached HEAD"
+  ! echo "$output" | grep -q "advice.detachedHead"
+}
+
+@test "install: exact tag install does not print detached-HEAD advice" {
+  create_remote_package "alpha" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run run_install "alpha@v1.0.0"
+  [ "$status" -eq 0 ]
+  [ "$(shiv_registry_ref_mode "alpha")" = "tag" ]
+  ! echo "$output" | grep -q "detached HEAD"
+  ! echo "$output" | grep -q "advice.detachedHead"
+}
+
+@test "install: switching release channel to a new tag does not print detached-HEAD advice" {
+  create_remote_package "alpha" "v1.0.0"
+  configure_remote_source "alpha"
+
+  run_install "alpha"
+  add_remote_package_tag "alpha" "v1.1.0"
+
+  run run_install "alpha"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "✓ Installed alpha@v1.1.0"
+  ! echo "$output" | grep -q "detached HEAD"
+  ! echo "$output" | grep -q "advice.detachedHead"
+}
+
 @test "install: switching to branch tracking refuses local branch commits" {
   create_remote_package "alpha" "v1.0.0"
   configure_remote_source "alpha"


### PR DESCRIPTION
Closes #126.

## Problem

Release-channel installs intentionally check out release tags, which leaves the managed package repo in detached HEAD — correct for immutable release installs, but Git prints its full detached-HEAD advisory on the happy path, making the normal `shiv install <pkg>` / `<pkg>@latest` flow look alarming:

```
Note: switching to 'v0.2.8'.

You are in 'detached HEAD' state. You can look around, ...
... Turn off this advice by setting config variable advice.detachedHead to false
```

## Fix

Add `-c advice.detachedHead=false` to the three intentionally-detached checkout/clone sites in `.mise/tasks/install`:

1. the in-place ref-switch checkout for `release`/`tag`/`commit` modes,
2. the `tag)` fresh-clone (the `@latest`/bare-release happy path),
3. the `commit)` fresh-clone checkout.

Branch checkouts (`branch)` clone, `checkout_branch_ref`) are deliberately left unchanged, and the flag only mutes the advisory — real checkout/fetch failures still surface their errors.

## Before / after (reproduced)

Mirroring the `tag)` clone path against a local bare remote with a tag:

```
$ git clone --branch v0.2.8 --depth 1 --single-branch <remote> before
  Note: switching to '66222c9...'.
  You are in 'detached HEAD' state. ...
  ... Turn off this advice by setting config variable advice.detachedHead to false

$ git -c advice.detachedHead=false clone --branch v0.2.8 --depth 1 --single-branch <remote> after
  (no advisory)
```

## Tests

Added 3 cases to `test/install.bats`, each asserting the output contains neither `detached HEAD` nor `advice.detachedHead`:

- `install: release install does not print detached-HEAD advice`
- `install: exact tag install does not print detached-HEAD advice`
- `install: switching release channel to a new tag does not print detached-HEAD advice`

These exercise both the `tag)` fresh-clone edit and the in-place ref-switch checkout edit. The commit-clone path shares the identical flag; remote commit-SHA installs aren't exercisable in the offline bats harness (fetch-by-SHA needs server-side `uploadpack.allowAnySHA1InWant`).

Local: `mise run test` → **269/269 pass** (incl. the 3 new). Change is added `-c` flags only — bash 3.2-safe for the macOS CI leg.

## Out of scope

Sibling #130 (the signed/annotated-tag `is not a commit` warning) is **not** suppressed by `advice.detachedHead` and will be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)