### PR TITLE
fix(uninstall): require --yes in non-interactive contexts instead of TTY crash (#75)

### DIFF
--- a/.mise/tasks/uninstall
+++ b/.mise/tasks/uninstall
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Remove a tool's shim and deregister it"
 #USAGE arg "<name>" help="Package name to remove"
-#USAGE flag "-y --yes" help="Skip confirmation prompt"
-#USAGE flag "--force" help="Override safety checks (e.g., uninstalling shiv)"
+#USAGE flag "-y --yes" default=#false help="Skip confirmation prompt"
+#USAGE flag "--force" default=#false help="Override safety checks (e.g., uninstalling shiv)"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/shim.sh"

--- a/.mise/tasks/uninstall
+++ b/.mise/tasks/uninstall
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Remove a tool's shim and deregister it"
 #USAGE arg "<name>" help="Package name to remove"
-#USAGE flag "-y --yes" default=#false help="Skip confirmation prompt"
-#USAGE flag "--force" default=#false help="Override safety checks (e.g., uninstalling shiv)"
+#USAGE flag "-y --yes" help="Skip confirmation prompt"
+#USAGE flag "--force" help="Override safety checks (e.g., uninstalling shiv)"
 set -eo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/shim.sh"

--- a/.mise/tasks/uninstall
+++ b/.mise/tasks/uninstall
@@ -75,8 +75,14 @@ echo ""
   echo "ALIASES${SEP}${alias_display}"
 } | gum table -s "$SEP" -c "KEY,VALUE" -p --border normal
 
-# Confirm before proceeding (unless -y or --force)
+# Confirm before proceeding (unless -y or --force). With no controlling TTY
+# there's no way to prompt, so require --yes explicitly instead of letting gum
+# fail with an opaque /dev/tty error.
 if [ "$YES" != "true" ]; then
+  if [ ! -t 0 ] && [ -z "${SHIV_ASSUME_TTY:-}" ]; then
+    echo "  ✗ No TTY available — re-run with --yes to skip confirmation" >&2
+    exit 1
+  fi
   echo ""
   "${GUM:-gum}" confirm "Proceed?" || { echo "Cancelled."; exit 0; }
 fi

--- a/test/uninstall.bats
+++ b/test/uninstall.bats
@@ -22,6 +22,9 @@ setup() {
   setup_shiv_on_path
 
   export SHIV_SKIP_CACHE=1
+
+  # bats runs with non-tty stdin; opt the confirm tests into the prompt branch.
+  export SHIV_ASSUME_TTY=1
 }
 
 
@@ -362,6 +365,16 @@ MOCK
   [ "$status" -eq 0 ]
   [ ! -f "$SHIV_BIN_DIR/alpha" ]
   echo "$output" | grep -q "✓ Uninstalled alpha"
+}
+
+@test "uninstall: non-interactive without --yes requires --yes" {
+  create_installed_package "alpha"
+  unset SHIV_ASSUME_TTY
+  run run_uninstall "alpha" </dev/null
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--yes"
+  # Nothing removed — the shim must survive
+  [ -f "$SHIV_BIN_DIR/alpha" ]
 }
 
 @test "uninstall: denied prompt cancels cleanly" {

--- a/test/uninstall.bats
+++ b/test/uninstall.bats
@@ -357,6 +357,17 @@ MOCK
 # Confirmation prompt
 # ============================================================================
 
+
+@test "uninstall: ambient usage_yes does not skip confirmation" {
+  create_installed_package "alpha"
+  mock_gum_confirm 1
+
+  run env usage_yes=true shiv uninstall alpha
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Cancelled."
+  [ -f "$SHIV_BIN_DIR/alpha" ]
+}
+
 @test "uninstall: confirmed prompt proceeds with uninstall" {
   create_installed_package "alpha"
   mock_gum_confirm 0

--- a/test/uninstall.bats
+++ b/test/uninstall.bats
@@ -357,17 +357,6 @@ MOCK
 # Confirmation prompt
 # ============================================================================
 
-
-@test "uninstall: ambient usage_yes does not skip confirmation" {
-  create_installed_package "alpha"
-  mock_gum_confirm 1
-
-  run env usage_yes=true shiv uninstall alpha
-  [ "$status" -eq 0 ]
-  echo "$output" | grep -q "Cancelled."
-  [ -f "$SHIV_BIN_DIR/alpha" ]
-}
-
 @test "uninstall: confirmed prompt proceeds with uninstall" {
   create_installed_package "alpha"
   mock_gum_confirm 0

--- a/test/uninstall.bats
+++ b/test/uninstall.bats
@@ -377,6 +377,24 @@ MOCK
   [ -f "$SHIV_BIN_DIR/alpha" ]
 }
 
+@test "uninstall: inherited usage_yes does not bypass confirmation" {
+  create_installed_package "alpha"
+  unset SHIV_ASSUME_TTY
+  usage_yes=true run run_uninstall "alpha" </dev/null
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--yes"
+  [ -f "$SHIV_BIN_DIR/alpha" ]
+}
+
+@test "uninstall: inherited usage_force does not bypass confirmation" {
+  create_installed_package "alpha"
+  unset SHIV_ASSUME_TTY
+  usage_force=true run run_uninstall "alpha" </dev/null
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q -- "--yes"
+  [ -f "$SHIV_BIN_DIR/alpha" ]
+}
+
 @test "uninstall: denied prompt cancels cleanly" {
   create_installed_package "alpha"
   mock_gum_confirm 1


### PR DESCRIPTION
Closes #75.

## Problem

`shiv uninstall <pkg>` with no `-y`/`--force` always calls `gum confirm`. In a non-interactive context (CI, pipe — no controlling TTY) gum can't open `/dev/tty` and dies with an opaque error that never mentions the `--yes` flag, so a missing-flag situation looks like an internal bug:

```
unable to confirm: could not open a new TTY: open /dev/tty: device not configured
Cancelled.
```

## Fix

Before prompting, detect the non-interactive case (`[ ! -t 0 ]`) and fail fast with an actionable, apt-style message requiring `--yes`, instead of letting gum crash:

```sh
if [ "$YES" != "true" ]; then
  if [ ! -t 0 ] && [ -z "${SHIV_ASSUME_TTY:-}" ]; then
    echo "  ✗ No TTY available — re-run with --yes to skip confirmation" >&2
    exit 1
  fi
  echo ""
  "${GUM:-gum}" confirm "Proceed?" || { echo "Cancelled."; exit 0; }
fi
```

The check sits at the prompt point — nothing destructive runs before it, and the summary card still prints. `--yes`/`--force` are unaffected (they skip the whole block). The `SHIV_ASSUME_TTY` escape hatch lets the bats suite exercise the prompt branch despite its non-tty stdin, mirroring the existing `SHIV_SKIP_CACHE` production toggle in `lib/cache.sh`.

## Before / after

```
# before — non-interactive (piped), no --yes
$ echo | shiv uninstall alpha
  ... unable to confirm: could not open a new TTY: open /dev/tty: device not configured
  Cancelled.            # opaque; --yes never mentioned

# after — non-interactive, no --yes
$ echo | shiv uninstall alpha
  ✗ No TTY available — re-run with --yes to skip confirmation   # exit 1

# after — non-interactive with --yes still works
$ shiv uninstall alpha --yes        # uninstalls, no prompt
```

## Tests

`test/uninstall.bats`:
- `setup()` exports `SHIV_ASSUME_TTY=1` so the existing `confirmed prompt proceeds` / `denied prompt cancels` tests keep hitting the mock-gum prompt branch unchanged.
- New test `uninstall: non-interactive without --yes requires --yes` — clears the toggle, runs with stdin `</dev/null`, asserts exit 1, `--yes` in the output, and that the shim survives (nothing removed).

Local: `mise run test` → **267/267 pass, 0 failures** (incl. all three confirm tests + the new one). Change is POSIX test primitives (`[ -t 0 ]`, `[ -z ... ]`) → bash 3.2-safe for the macOS CI leg.

## Open questions

- Detection via `[ -t 0 ]` (stdin, apt-style) vs probing `/dev/tty` openability. Chose `[ -t 0 ]` — simpler and conventional; the rare interactive-but-stdin-redirected case would now refuse (acceptable, apt-consistent).
- `SHIV_ASSUME_TTY` test toggle follows the `SHIV_SKIP_CACHE` precedent — OK, or prefer a different name?
- Scope kept to `uninstall` (single confirm site). Happy to generalize into a `shiv_can_prompt` helper if you'd like the sibling confirm-or-require-yes issues (#89) to reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)