### PR TITLE
fix(install): avoid "is not a commit!" warning on annotated tag installs (#130)

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -179,8 +179,13 @@ else
         gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --branch "$REF" --single-branch "$CLONE_URL" "$TOOL_PATH"
         ;;
       tag)
-        # Cloning a tag lands in detached HEAD by design — suppress the advisory.
-        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git -c advice.detachedHead=false clone --branch "$REF" --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"
+        # `clone --branch <tag>` emits "warning: refs/tags/X is not a commit!" for
+        # annotated/signed tags. Clone the default branch, then fetch the tag
+        # explicitly (creates the local tag ref that list/describe rely on) and
+        # check it out; suppress the detached-HEAD advisory.
+        gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"
+        git -C "$TOOL_PATH" fetch --depth 1 origin tag "$REF" 2>&1 | sed 's/^/  /'
+        git -C "$TOOL_PATH" -c advice.detachedHead=false checkout "$REF" 2>&1 | sed 's/^/  /'
         ;;
       commit)
         gum spin --title "  Cloning $GH_REPO@$REF..." --show-error -- git clone --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"

--- a/test/install.bats
+++ b/test/install.bats
@@ -443,6 +443,7 @@ MOCK
   [ "$status" -eq 0 ]
   ! echo "$output" | grep -q "detached HEAD"
   ! echo "$output" | grep -q "advice.detachedHead"
+  ! echo "$output" | grep -q "is not a commit"
 }
 
 @test "install: exact tag install does not print detached-HEAD advice" {
@@ -454,6 +455,19 @@ MOCK
   [ "$(shiv_registry_ref_mode "alpha")" = "tag" ]
   ! echo "$output" | grep -q "detached HEAD"
   ! echo "$output" | grep -q "advice.detachedHead"
+  ! echo "$output" | grep -q "is not a commit"
+}
+
+@test "install: annotated tag install emits no 'is not a commit' warning" {
+  # create_remote_package tags are annotated (git tag -a), like signed releases.
+  create_remote_package "alpha" "v1.0.0" "v1.2.0"
+  configure_remote_source "alpha"
+
+  run run_install "alpha"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q "is not a commit"
+  # Tag ref must still resolve locally (used by list/describe) at the right commit
+  [ "$(git -C "$SHIV_PACKAGES_DIR/alpha" describe --tags --exact-match HEAD)" = "v1.2.0" ]
 }
 
 @test "install: switching release channel to a new tag does not print detached-HEAD advice" {


### PR DESCRIPTION
Closes #130. **Builds on #137 (#126)** — stacked branch; until #137 merges this PR's diff also
shows #137's commit (`80061c3`). **Merge #137 first**, then this narrows to its own change.

## Problem

`shiv install` on a signed release tag prints a confusing Git warning during checkout:

```
  Cloning KnickKnackLabs/sphincters@v0.1.0...
warning: refs/tags/v0.1.0 081025d… is not a commit!
Note: switching to '7536cfd…'.
```

The warning is intrinsic to `git clone --branch <tag>` when the tag is an **annotated** (signed)
object rather than a commit. The release guide recommends signed tags, so this shows on the
normal release-install path. (#137/#126 muted the detached-HEAD *advice* but not this warning.)

## Fix

Stop using `git clone --branch <tag>` for tag installs. Clone the default branch, fetch the tag
explicitly, then check it out — mirroring the existing `commit)` flow:

```sh
tag)
  git clone --depth 1 --single-branch "$CLONE_URL" "$TOOL_PATH"
  git -C "$TOOL_PATH" fetch --depth 1 origin tag "$REF"        # creates local tag ref
  git -C "$TOOL_PATH" -c advice.detachedHead=false checkout "$REF"
  ;;
```

Fetching the tag explicitly creates the local `refs/tags/<ref>` that `list` / `git describe`
rely on, and a plain `checkout <tag>` (unlike `clone --branch`) does not emit the warning. The
in-place release/tag *switch* path and the `commit)` path already use `checkout`, so they were
never affected.

## Before / after (reproduced against a local annotated-tag remote)

```
# before — clone --branch <annotated-tag> (with or without --depth/--single-branch)
$ git clone --branch v0.1.0 --depth 1 --single-branch <remote> pkg
  warning: refs/tags/v0.1.0 edf2db7… is not a commit!     # <-- the warning

# after — clone default, fetch tag, checkout
$ git clone --depth 1 --single-branch <remote> pkg
$ git -C pkg fetch --depth 1 origin tag v0.1.0
$ git -C pkg -c advice.detachedHead=false checkout v0.1.0
  HEAD is now at 48f9f34 init                              # clean
$ git -C pkg describe --tags --exact-match HEAD
  v0.1.0                                                   # tag ref intact
```

## Tests

`test/install.bats` (harness tags are annotated — `create_remote_package` uses `git tag -a`):
- Added `! grep "is not a commit"` to the release-install and exact-tag-install tests.
- New `install: annotated tag install emits no 'is not a commit' warning` — asserts no warning
  and that `git describe --tags --exact-match HEAD` returns the tag (tag ref + correct commit).

Local: `mise run test` → **270/270 pass, 0 failures**. Plain git + `sed` → bash 3.2-safe for the
macOS CI leg.

## Open question

Tag fetch is shallow (`--depth 1`, matching the `commit)` path) for speed/parity. If you'd prefer
full history on release installs, I can drop `--depth 1` on the tag fetch.

