### PR TITLE
Register voice package

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,38 +1,85 @@
 #!/usr/bin/env bash
 #MISE description="Run BATS tests"
-#USAGE arg "[args]..." var=#true help="Test suites or bats arguments"
+#USAGE arg "[args]" default="" var=#true help="Test suites or bats arguments"
 #USAGE example "mise run test" header="Run all tests"
 #USAGE example "mise run test doctor" header="Run a specific suite by name"
 #USAGE example "mise run test test/format.bats" header="Run a specific file"
-#USAGE example "mise run test -- --filter rejects" header="Filter tests by name"
+#USAGE example "mise run test --filter rejects" header="Filter tests by name"
 set -euo pipefail
 
 TEST_DIR="$MISE_CONFIG_ROOT/test"
 
-# Completions excluded from default run — requires fish/zsh, has its own workflow
+# Completions are excluded from the default run — they require fish/zsh and
+# have their own workflow. Explicit targets can still run completions.
 EXCLUDE="completions"
 
 args=()
-has_target=false
-
-for arg in "$@"; do
-  if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
-    args+=("$TEST_DIR/$arg.bats")
-    has_target=true
-  else
-    [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+if [ -n "${usage_args:-}" ]; then
+  while IFS= read -r arg; do
+    [ -z "$arg" ] && continue
     args+=("$arg")
+  done < <(printf '%s' "${usage_args}" | xargs printf '%s\n')
+fi
+
+bats_option_takes_value() {
+  case "$1" in
+    # Filtering
+    -f|--filter|--negative-filter|--filter-status|--filter-tags)
+      return 0
+      ;;
+    # Output/report formatting
+    -F|--formatter|--report-formatter|-o|--output)
+      return 0
+      ;;
+    # Parallel execution
+    -j|--jobs|--parallel-binary-name)
+      return 0
+      ;;
+    # Misc BATS options with separate values
+    --code-quote-style|--line-reference-format|--gather-test-outputs-in)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+resolved=()
+has_target=false
+expect_option_value=false
+
+for arg in ${args[@]+"${args[@]}"}; do
+  if $expect_option_value; then
+    resolved+=("$arg")
+    expect_option_value=false
+    continue
   fi
+
+  if bats_option_takes_value "$arg"; then
+    resolved+=("$arg")
+    expect_option_value=true
+    continue
+  fi
+
+  if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
+    resolved+=("$TEST_DIR/$arg.bats")
+    has_target=true
+    continue
+  fi
+
+  [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+  resolved+=("$arg")
 done
 
 bats_args=()
-
 if ! $has_target; then
   for f in "$TEST_DIR"/*.bats; do
     [[ "$(basename "$f" .bats)" == "$EXCLUDE" ]] && continue
-    args+=("$f")
+    resolved+=("$f")
   done
-  bats_args+=(--jobs 8 --parallel-binary-name rush)
+
+  if [ ${#args[@]} -eq 0 ]; then
+    bats_args+=(--jobs 8 --parallel-binary-name rush)
+  fi
 fi
 
-exec bats ${bats_args[@]+"${bats_args[@]}"} ${args[@]+"${args[@]}"}
+exec bats ${bats_args[@]+"${bats_args[@]}"} ${resolved[@]+"${resolved[@]}"}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 294 passing](https://img.shields.io/badge/tests-294%20passing-brightgreen?style=flat)
-![packages: 39](https://img.shields.io/badge/packages-39-blue?style=flat)
+![tests: 277 passing](https://img.shields.io/badge/tests-277%20passing-brightgreen?style=flat)
+![packages: 42](https://img.shields.io/badge/packages-42-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -148,7 +148,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — 294 tests across 14 suites.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 277 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/sources.json
+++ b/sources.json
@@ -36,6 +36,7 @@
   "testicles": "KnickKnackLabs/testicles",
   "threads": "KnickKnackLabs/threads",
   "tits": "KnickKnackLabs/tits",
+  "voice": "KnickKnackLabs/voice",
   "wallpapers": "KnickKnackLabs/wallpapers",
   "websites": "KnickKnackLabs/websites",
   "winnie": "KnickKnackLabs/winnie",

--- a/test/test-task.bats
+++ b/test/test-task.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+# shiv test task regression suite
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+
+run_test_count() {
+  cd "$REPO_DIR" && mise run -q test "$@" -c 2>"$BATS_TEST_TMPDIR/test-task-stderr"
+}
+
+@test "test task resolves bare suite names" {
+  run run_test_count registry
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "test task supports flag-only BATS filters" {
+  run run_test_count --filter "sources: default index includes portl"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "test task does not treat filter values as suite targets" {
+  run run_test_count --filter registry
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 1 ]
+}


### PR DESCRIPTION
## Summary

- register `KnickKnackLabs/voice` in the default shiv package index
- bring shiv's `test` task closer to the current KKL template behavior so flag-only BATS invocations like `mise run test --filter registry` get a default test target
- add regression coverage for bare suite names and flag-only filters
- refresh README package/test counts

## Validation

- `mise run test test-task registry`
- `mise run registry:validate`
- `codebase lint "$PWD"`
- `git diff --check`
- `mise run test` (default suite: 277 tests; completions excluded as before)

## Notes

`KnickKnackLabs/voice@d55c12f` is the initial pushed voice capture tool. Its CI push run is green.
