### PR TITLE
Add whora to package sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![tests: 277 passing](https://img.shields.io/badge/tests-277%20passing-brightgreen?style=flat)
-![packages: 42](https://img.shields.io/badge/packages-42-blue?style=flat)
+![packages: 43](https://img.shields.io/badge/packages-43-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>

--- a/README.tsx
+++ b/README.tsx
@@ -23,7 +23,8 @@ const packageCount = Object.keys(packages).length;
 // Count test files and test cases
 const testDir = join(REPO_DIR, "test");
 const testFiles = readdirSync(testDir).filter((f) => f.endsWith(".bats"));
-const testCount = testFiles.reduce((sum, f) => {
+const defaultTestFiles = testFiles.filter((f) => f !== "completions.bats");
+const testCount = defaultTestFiles.reduce((sum, f) => {
   const content = readFileSync(join(testDir, f), "utf-8");
   return sum + (content.match(/@test /g)?.length ?? 0);
 }, 0);
@@ -230,8 +231,8 @@ cd shiv && mise trust && mise install
 mise run test`}</CodeBlock>
 
       <Paragraph>
-        Tests use <Link href="https://github.com/bats-core/bats-core">BATS</Link> — {testCount} tests
-        across {testFiles.length} suites.
+        Tests use <Link href="https://github.com/bats-core/bats-core">BATS</Link> — the default run covers {testCount} tests
+        across {defaultTestFiles.length} suites. Completion tests run separately.
       </Paragraph>
     </Section>
 

--- a/sources.json
+++ b/sources.json
@@ -39,6 +39,7 @@
   "voice": "KnickKnackLabs/voice",
   "wallpapers": "KnickKnackLabs/wallpapers",
   "websites": "KnickKnackLabs/websites",
+  "whora": "KnickKnackLabs/whora",
   "winnie": "KnickKnackLabs/winnie",
   "zettelkasten": "KnickKnackLabs/zettelkasten"
 }


### PR DESCRIPTION
## Summary

- add `whora` to the default shiv package source index
- regenerate README package count
- adjust README test counting to match the default `mise run test` behavior, excluding `completions.bats` which runs separately

## Merge sequencing

Merge this after KnickKnackLabs/whora#1 lands and `whora` has an initial semver tag/release. Bare `shiv install whora` resolves the release channel by default, so the package should have a first release before it enters the default index.

## Validation

- `mise run test` — 277/277
- `mise run test registry` — 47/47
- `codebase lint "$PWD"`
- `mise exec -- readme build --check`
- `git diff --check`

Related: KnickKnackLabs/whora#1
