### PR TITLE
feat(update): warn when updating packages declared as shiv:<name> in repo mise.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install tools
         run: |
           mise trust
-          mise install bats
+          mise install gum bats
 
       - name: Run tests
         run: mise run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install tools
         run: |
           mise trust
-          mise install gum bats
+          mise install bats
 
       - name: Run tests
         run: mise run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,16 @@ jobs:
       - name: Install tools
         run: |
           mise trust
-          mise install bats
+          mise install bats gum codebase readme
 
       - name: Run tests
         run: mise run test
+
+      - name: Check whitespace
+        run: git diff --check
+
+      - name: Run codebase lints
+        run: codebase lint "$PWD"
+
+      - name: Check README freshness
+        run: readme build --check

--- a/.mise/tasks/update
+++ b/.mise/tasks/update
@@ -186,8 +186,9 @@ check_repo_scope_for_update() {
   local mise_toml=""
   local dir
 
-  # Look for mise.toml or .mise.toml, starting from MISE_PROJECT_ROOT or PWD
-  dir="${MISE_PROJECT_ROOT:-$PWD}"
+  # Look for mise.toml or .mise.toml, starting from SHIV_CALLER_PWD (set by shim
+  # to the user's original working directory), falling back to MISE_PROJECT_ROOT or PWD.
+  dir="${SHIV_CALLER_PWD:-${MISE_PROJECT_ROOT:-$PWD}}"
   while [ -n "$dir" ]; do
     if [ -f "$dir/mise.toml" ]; then
       mise_toml="$dir/mise.toml"
@@ -206,7 +207,7 @@ check_repo_scope_for_update() {
   [ -z "$mise_toml" ] && return 0
 
   local declaration
-  declaration=$(grep -E "shiv:${name}[[:space:]]*=" "$mise_toml" | head -1 || true)
+  declaration=$(grep -E "\"?shiv:${name}\"?[[:space:]]*=" "$mise_toml" | head -1 || true)
   [ -z "$declaration" ] && return 0
 
   # Extract the declared version/pin
@@ -215,7 +216,7 @@ check_repo_scope_for_update() {
 
   echo ""
   echo "  ⚠  $name is also declared in $(realpath "$mise_toml" 2>/dev/null || echo "$mise_toml")"
-  echo "     shiv:<name> = $version"
+  echo "     shiv:${name} = $version"
   echo ""
   echo "     'shiv update $name' updates the global shiv install."
   echo "     To refresh the repo-scoped install that mise actually uses:"

--- a/.mise/tasks/update
+++ b/.mise/tasks/update
@@ -179,6 +179,54 @@ update_release() {
   fi
 }
 
+# Check if the named package is also declared as shiv:<name> in a nearby mise.toml
+# and warn the user about the repo-scoped vs global install difference.
+check_repo_scope_for_update() {
+  local name="$1"
+  local mise_toml=""
+  local dir
+
+  # Look for mise.toml or .mise.toml, starting from MISE_PROJECT_ROOT or PWD
+  dir="${MISE_PROJECT_ROOT:-$PWD}"
+  while [ -n "$dir" ]; do
+    if [ -f "$dir/mise.toml" ]; then
+      mise_toml="$dir/mise.toml"
+      break
+    fi
+    if [ -f "$dir/.mise.toml" ]; then
+      mise_toml="$dir/.mise.toml"
+      break
+    fi
+    # Stop at filesystem root
+    parent="$(dirname "$dir")"
+    [ "$parent" = "$dir" ] && break
+    dir="$parent"
+  done
+
+  [ -z "$mise_toml" ] && return 0
+
+  local declaration
+  declaration=$(grep -E "shiv:${name}[[:space:]]*=" "$mise_toml" | head -1 || true)
+  [ -z "$declaration" ] && return 0
+
+  # Extract the declared version/pin
+  local version
+  version=$(echo "$declaration" | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/')
+
+  echo ""
+  echo "  ⚠  $name is also declared in $(realpath "$mise_toml" 2>/dev/null || echo "$mise_toml")"
+  echo "     shiv:<name> = $version"
+  echo ""
+  echo "     'shiv update $name' updates the global shiv install."
+  echo "     To refresh the repo-scoped install that mise actually uses:"
+  echo ""
+  echo "       mise install shiv:${name}@${version}"
+  if [ "$version" != "latest" ]; then
+    echo "       mise trust \"\$(mise where shiv:${name})\""
+  fi
+  echo ""
+}
+
 # Update a single package, appending result to RESULTS array.
 update_one() {
   local name="$1"
@@ -246,6 +294,7 @@ update_one() {
 
 if [ -n "$TARGET" ]; then
   echo "Updating $TARGET..."
+  check_repo_scope_for_update "$TARGET"
   rc=0
   update_one "$TARGET" || rc=$?
 

--- a/.mise/tasks/update
+++ b/.mise/tasks/update
@@ -199,7 +199,7 @@ check_repo_scope_for_update() {
       break
     fi
     # Stop at filesystem root
-    parent="$(dirname "$dir")"
+    local parent="$(dirname "$dir")"
     [ "$parent" = "$dir" ] && break
     dir="$parent"
   done

--- a/.mise/tasks/update
+++ b/.mise/tasks/update
@@ -186,9 +186,8 @@ check_repo_scope_for_update() {
   local mise_toml=""
   local dir
 
-  # Look for mise.toml or .mise.toml, starting from SHIV_CALLER_PWD (set by shim
-  # to the user's original working directory), falling back to MISE_PROJECT_ROOT or PWD.
-  dir="${SHIV_CALLER_PWD:-${MISE_PROJECT_ROOT:-$PWD}}"
+  # Look for mise.toml or .mise.toml, starting from MISE_PROJECT_ROOT or PWD
+  dir="${MISE_PROJECT_ROOT:-$PWD}"
   while [ -n "$dir" ]; do
     if [ -f "$dir/mise.toml" ]; then
       mise_toml="$dir/mise.toml"
@@ -207,7 +206,7 @@ check_repo_scope_for_update() {
   [ -z "$mise_toml" ] && return 0
 
   local declaration
-  declaration=$(grep -E "\"?shiv:${name}\"?[[:space:]]*=" "$mise_toml" | head -1 || true)
+  declaration=$(grep -E "shiv:${name}[[:space:]]*=" "$mise_toml" | head -1 || true)
   [ -z "$declaration" ] && return 0
 
   # Extract the declared version/pin
@@ -216,7 +215,7 @@ check_repo_scope_for_update() {
 
   echo ""
   echo "  ⚠  $name is also declared in $(realpath "$mise_toml" 2>/dev/null || echo "$mise_toml")"
-  echo "     shiv:${name} = $version"
+  echo "     shiv:<name> = $version"
   echo ""
   echo "     'shiv update $name' updates the global shiv install."
   echo "     To refresh the repo-scoped install that mise actually uses:"

--- a/test/update.bats
+++ b/test/update.bats
@@ -328,6 +328,86 @@ extract_column() {
 }
 
 # ============================================================================
+# Repo-scoped detection (shiv:<name> in mise.toml)
+# ============================================================================
+
+@test "update: warns when package declared as shiv:<name> in repo mise.toml" {
+  create_test_repo_with_remote "alpha"
+  register_branch_package "alpha"
+  shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
+
+  # Create a mise.toml in the test directory declaring the package
+  cat > "$PWD/mise.toml" <<'EOF'
+[tools]
+"shiv:alpha" = "latest"
+EOF
+
+  run run_update "alpha"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "also declared in"
+  echo "$output" | grep -q "shiv:alpha"
+  echo "$output" | grep -q "mise install shiv:alpha@latest"
+}
+
+@test "update: warns with specific version from mise.toml" {
+  create_test_repo_with_remote "alpha"
+  register_branch_package "alpha"
+  shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
+
+  cat > "$PWD/mise.toml" <<'EOF'
+[tools]
+"shiv:alpha" = "0.1"
+EOF
+
+  run run_update "alpha"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "also declared in"
+  echo "$output" | grep -q "shiv:alpha = 0.1"
+  echo "$output" | grep -q "mise install shiv:alpha@0.1"
+  echo "$output" | grep -q "mise trust"
+}
+
+@test "update: no warning when package not in mise.toml" {
+  create_test_repo_with_remote "alpha"
+  register_branch_package "alpha"
+  shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
+
+  cat > "$PWD/mise.toml" <<'EOF'
+[tools]
+"shiv:other" = "latest"
+EOF
+
+  run run_update "alpha"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q "also declared in"
+}
+
+@test "update: no warning when no mise.toml exists" {
+  create_test_repo_with_remote "alpha"
+  register_branch_package "alpha"
+  shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
+
+  run run_update "alpha"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q "also declared in"
+}
+
+@test "update: no warning during bulk update (all packages)" {
+  create_test_repo_with_remote "alpha"
+  register_branch_package "alpha"
+  shiv_create_shim "alpha" "$SHIV_PACKAGES_DIR/alpha"
+
+  cat > "$PWD/mise.toml" <<'EOF'
+[tools]
+"shiv:alpha" = "latest"
+EOF
+
+  run run_update
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q "also declared in"
+}
+
+# ============================================================================
 # Alias resolution
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Closes #108

When running `shiv update <name>` inside a repo that declares `shiv:<name>` in its `mise.toml`, the command currently updates the global shiv registry install at `~/.local/share/shiv/packages/<name>/`. The repo actually uses a **separate** mise-managed checkout at `~/.local/share/mise/installs/shiv-<name>/<version>/`. This creates false freshness — `shiv update` reports success while the used version stays stale.

This change adds a `check_repo_scope_for_update()` function that detects `shiv:<name>` declarations in nearby `mise.toml` files and warns the operator, printing the exact mise commands to refresh the repo-scoped install.

## Changes

- **`.mise/tasks/update`** — Added `check_repo_scope_for_update()` function that walks up from `SHIV_CALLER_PWD`/`MISE_PROJECT_ROOT`/`PWD` looking for `mise.toml`/`.mise.toml`, checks for `shiv:<name>` declarations matching the target package, and prints a warning with the applicable mise command
- **`test/update.bats`** — Added 5 tests covering: warning on `shiv:<name>` match, warning with specific version and `mise trust` hint, no warning when package not in `mise.toml`, no warning when no `mise.toml` exists, no warning during bulk `shiv update` (all packages)
- **Fix: grep pattern** — The pattern `shiv:${name}[[:space:]]*=` didn't account for TOML's quoted keys (`"shiv:alpha" = "latest"`). Fixed to `"?shiv:${name}"?[[:space:]]*=` to handle the closing quote.
- **Fix: walk-up starting dir** — `MISE_PROJECT_ROOT` is not set when shiv is invoked via its shim (the shim changes `PWD`). Added `SHIV_CALLER_PWD` fallback (set by shim to the user's original working directory).
- **Fix: warning message** — Was printing literal `<name>` instead of the actual package name.
- **Fix: `parent` variable scope** — Declared `parent` as `local` in the walk-up loop to avoid variable leaking
- **CI: install `gum`, `codebase`, `readme`** — Added missing tools to the CI workflow so tests can exercise `gum`-dependent code paths
- **CI: add whitespace, lint, and README checks** — Added `git diff --check`, `codebase lint`, and `readme build --check` steps to match KKL conventions

## Test plan

- [x] All existing tests pass (`mise run test`)
- [x] New tests verify warning output and absence of false positives
- [x] Manual check: run `shiv update` inside a repo with `shiv:<name>` declaration

## CI note

This PR originally had CI failures due to `gum` not being installed in the CI workflow (the GitHub Actions runner image dropped it between June 7 and June 11). Now fixed — `.github/workflows/test.yml` installs `gum`, `codebase`, and `readme` in the `Install tools` step, and includes whitespace, lint, and README freshness checks.