### PR TITLE
fix: clear mise override during package install

### DIFF
--- a/.mise/tasks/doctor
+++ b/.mise/tasks/doctor
@@ -16,8 +16,8 @@ COUNT=$(jq 'length' "$SHIV_REGISTRY")
 
 # Schema validation
 schema_status="✓ valid ($COUNT packages)"
-if command -v jsonschema &>/dev/null; then
-  if ! jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY" 2>/dev/null; then
+if mise which jsonschema &>/dev/null; then
+  if ! mise x -- jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY" 2>/dev/null; then
     schema_status="✗ invalid — run 'shiv registry:validate'"
     HAS_ISSUES=true
   fi

--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -202,7 +202,7 @@ if [ -f "$TOOL_PATH/mise.toml" ]; then
   # Set up dependencies after resolving TOOL_PATH so both package installs and
   # local path installs trust/install the tool repo before shim creation.
   printf -v escaped_path '%q' "$TOOL_PATH"
-  dep_output=$(gum spin --title "  Setting up dependencies..." -- bash -c "cd $escaped_path && mise trust -q 2>&1 && mise install -q 2>&1") || {
+  dep_output=$(gum spin --title "  Setting up dependencies..." -- bash -c "cd $escaped_path && unset MISE_OVERRIDE_CONFIG_FILENAMES && mise trust -q 2>&1 && mise install -q 2>&1") || {
     echo "  ✗ Failed to install dependencies for $NAME" >&2
     echo "$dep_output" | strip_ansi | sed 's/^/    /' >&2
     exit 1

--- a/.mise/tasks/registry/validate
+++ b/.mise/tasks/registry/validate
@@ -7,11 +7,11 @@ source "$REPO_DIR/lib/registry.sh"
 
 shiv_init_registry
 
-if ! command -v jsonschema &>/dev/null; then
+if ! mise which jsonschema &>/dev/null; then
   echo "Error: jsonschema not found" >&2
   echo "Install with: mise install jsonschema" >&2
   exit 1
 fi
 
-jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+mise x -- jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
 echo "✓ Registry is valid"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 277 passing](https://img.shields.io/badge/tests-277%20passing-brightgreen?style=flat)
+![tests: 281 passing](https://img.shields.io/badge/tests-281%20passing-brightgreen?style=flat)
 ![packages: 45](https://img.shields.io/badge/packages-45-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -148,7 +148,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 277 tests across 14 suites. Completion tests run separately.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 281 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -13,9 +13,24 @@ shiv_cache_tasks() {
   local cache="$SHIV_CACHE_DIR/completions/$name.cache"
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/completions"
-  mise tasks --json -C "$repo_dir" 2>/dev/null \
-    | jq -r '.[] | select(.hide == false) | "\(.name)\t\(.description)"' \
-    > "$tmp"
+  local tasks_json
+  if ! tasks_json=$(
+    unset MISE_OVERRIDE_CONFIG_FILENAMES
+    mise tasks --json -C "$repo_dir" 2>/dev/null
+  ); then
+    rm -f "$tmp"
+    return 0
+  fi
+  if [ -z "$tasks_json" ]; then
+    rm -f "$tmp"
+    return 0
+  fi
+  if ! printf '%s\n' "$tasks_json" \
+    | jq -r '.[] | select(.global != true) | select(.hide == false) | "\(.name)\t\(.description)"' \
+    > "$tmp"; then
+    rm -f "$tmp"
+    return 0
+  fi
   if [ -s "$tmp" ]; then
     mv "$tmp" "$cache"
   else
@@ -39,8 +54,20 @@ shiv_cache_task_map() {
   local cache="$SHIV_CACHE_DIR/tasks/$name"
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/tasks"
-  if ! mise tasks --json --hidden -C "$repo_dir" 2>/dev/null \
-    | jq -r '.[].name | gsub(":"; " ")' \
+  local tasks_json
+  if ! tasks_json=$(
+    unset MISE_OVERRIDE_CONFIG_FILENAMES
+    mise tasks --json --hidden -C "$repo_dir" 2>/dev/null
+  ); then
+    rm -f "$tmp"
+    return 0
+  fi
+  if [ -z "$tasks_json" ]; then
+    rm -f "$tmp"
+    return 0
+  fi
+  if ! printf '%s\n' "$tasks_json" \
+    | jq -r '.[] | select(.global != true) | .name | gsub(":"; " ")' \
     > "$tmp"; then
     rm -f "$tmp"
     return 0

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -3,6 +3,19 @@
 
 SHIV_CACHE_DIR="${SHIV_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/shiv}"
 
+# Return package-local task metadata from mise without inheriting caller-scoped
+# config overrides. Shiv caches describe the managed package, not the repo or CI
+# wrapper that happened to invoke shiv.
+shiv_package_tasks_json() {
+  local repo_dir="$1"
+  shift
+
+  (
+    unset MISE_OVERRIDE_CONFIG_FILENAMES
+    mise tasks --json "$@" -C "$repo_dir" 2>/dev/null
+  )
+}
+
 # Cache task list for a tool (name<TAB>description per line)
 # Writes atomically — only replaces cache if new content is non-empty,
 # so a failed mise invocation doesn't leave an empty cache file.
@@ -14,10 +27,7 @@ shiv_cache_tasks() {
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/completions"
   local tasks_json
-  if ! tasks_json=$(
-    unset MISE_OVERRIDE_CONFIG_FILENAMES
-    mise tasks --json -C "$repo_dir" 2>/dev/null
-  ); then
+  if ! tasks_json=$(shiv_package_tasks_json "$repo_dir"); then
     rm -f "$tmp"
     return 0
   fi
@@ -55,10 +65,7 @@ shiv_cache_task_map() {
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/tasks"
   local tasks_json
-  if ! tasks_json=$(
-    unset MISE_OVERRIDE_CONFIG_FILENAMES
-    mise tasks --json --hidden -C "$repo_dir" 2>/dev/null
-  ); then
+  if ! tasks_json=$(shiv_package_tasks_json "$repo_dir" --hidden); then
     rm -f "$tmp"
     return 0
   fi

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -91,8 +91,20 @@ _shiv_check_cwd() {
   fi
 }
 
-# NOTE: the mise tasks | jq pipeline below duplicates shiv_cache_task_map()
-# in lib/cache.sh (shim self-containment). If you change the format, update both.
+_shiv_package_tasks_json() {
+  unset MISE_OVERRIDE_CONFIG_FILENAMES
+  mise tasks --json "\$@" -C "\$REPO" 2>/dev/null
+}
+
+_shiv_exec_package_mise() {
+  unset MISE_OVERRIDE_CONFIG_FILENAMES
+  exec mise -C "\$REPO" "\$@"
+}
+
+# NOTE: the task-map transformation duplicates shiv_cache_task_map() in
+# lib/cache.sh (shim self-containment). If you change package-task cache
+# invariants, update both places: scrub caller-scoped mise config overrides and
+# exclude global mise tasks.
 _shiv_ensure_task_map() {
   [ -f "\$SHIV_TASK_MAP" ] && return 0
   if ! command -v jq >/dev/null 2>&1; then
@@ -101,8 +113,17 @@ _shiv_ensure_task_map() {
   fi
   mkdir -p "\$(dirname "\$SHIV_TASK_MAP")"
   local tmp="\$SHIV_TASK_MAP.tmp"
-  if ! mise tasks --json --hidden -C "\$REPO" 2>/dev/null \\
-    | jq -r '.[].name | gsub(":"; " ")' > "\$tmp" 2>/dev/null; then
+  local tasks_json
+  if ! tasks_json=\$(_shiv_package_tasks_json --hidden); then
+    rm -f "\$tmp"
+    return 0
+  fi
+  if [ -z "\$tasks_json" ]; then
+    rm -f "\$tmp"
+    return 0
+  fi
+  if ! printf '%s\n' "\$tasks_json" \\
+    | jq -r '.[] | select(.global != true) | .name | gsub(":"; " ")' > "\$tmp" 2>/dev/null; then
     rm -f "\$tmp"
     return 0
   fi
@@ -124,10 +145,15 @@ _shiv_render_tasks() {
     return 1
   fi
 
-  local tmp repo_prefix
+  local tmp repo_prefix tasks_json
   tmp=\$(mktemp)
   repo_prefix="\$(cd "\$REPO" && pwd -P)/"
-  if ! mise -C "\$REPO" tasks --local --json 2>/dev/null \
+  if ! tasks_json=\$(_shiv_package_tasks_json --local); then
+    rm -f "\$tmp"
+    echo "$name: failed to render package-local task list" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "\$tasks_json" \
     | jq -r --arg repo_prefix "\$repo_prefix" '[.[] | select(.hide != true) | select(((.source // .file // "") | startswith(\$repo_prefix))) | (.name | split(":")) as \$p | {
         group: (if (\$p | length) > 1 then \$p[0] else "root" end),
         task: (if (\$p | length) > 1 then (\$p[1:] | join(":")) else .name end),
@@ -166,7 +192,7 @@ _shiv_render_tasks() {
 
 _shiv_handle_tasks() {
   if [ "\$HAS_TASKS_TASK" = "true" ]; then
-    exec mise -C "\$REPO" run -q "\$@"
+    _shiv_exec_package_mise run -q "\$@"
   fi
   _shiv_render_tasks
   local rc=\$?
@@ -181,7 +207,7 @@ _shiv_handle_help() {
   # Package-owned help wins. This lets tools expose richer help than the
   # generic mise task list while keeping the shim-level interception.
   if [ "\$HAS_HELP_TASK" = "true" ]; then
-    exec mise -C "\$REPO" run -q help
+    _shiv_exec_package_mise run -q help
   fi
 
   # Single-command tools (.mise/tasks/<name>) should show the command help,
@@ -189,9 +215,9 @@ _shiv_handle_help() {
   # menus/catch-alls where task-list help is still the safer default.
   if [ -n "\$DEFAULT_TASK" ] && [ "\$DEFAULT_TASK" != "_default" ]; then
     if [ "\$help_arg" = "help" ]; then
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" help
+      _shiv_exec_package_mise run -q "\$DEFAULT_TASK" help
     else
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$help_arg"
+      _shiv_exec_package_mise run -q "\$DEFAULT_TASK" "\$help_arg"
     fi
   fi
 
@@ -229,7 +255,7 @@ case "\${1:-}" in
     # --- Default task handling ---
     # No args: run default task directly.
     if [ -n "\$DEFAULT_TASK" ] && [ -z "\${1:-}" ]; then
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK"
+      _shiv_exec_package_mise run -q "\$DEFAULT_TASK"
     fi
 
     # "--" as first arg: explicit disambiguation — send everything
@@ -237,9 +263,9 @@ case "\${1:-}" in
     if [ -n "\$DEFAULT_TASK" ] && [ "\${1:-}" = "--" ]; then
       shift
       if [ \$# -gt 0 ]; then
-        exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$@"
+        _shiv_exec_package_mise run -q "\$DEFAULT_TASK" "\$@"
       else
-        exec mise -C "\$REPO" run -q "\$DEFAULT_TASK"
+        _shiv_exec_package_mise run -q "\$DEFAULT_TASK"
       fi
     fi
 
@@ -271,18 +297,18 @@ case "\${1:-}" in
       # Guard: only expand SHIV_RESOLVED_ARGS when non-empty.
       # bash <4.4 treats "\${empty_array[@]}" as unbound under set -u.
       if [ \${#SHIV_RESOLVED_ARGS[@]} -gt 0 ]; then
-        exec mise -C "\$REPO" run -q "\$SHIV_RESOLVED_TASK" "\${SHIV_RESOLVED_ARGS[@]}"
+        _shiv_exec_package_mise run -q "\$SHIV_RESOLVED_TASK" "\${SHIV_RESOLVED_ARGS[@]}"
       else
-        exec mise -C "\$REPO" run -q "\$SHIV_RESOLVED_TASK"
+        _shiv_exec_package_mise run -q "\$SHIV_RESOLVED_TASK"
       fi
     elif [ "\$_shiv_rc" -eq 1 ]; then
       exit 1  # ambiguous — error already printed to stderr
     fi
     # rc=2 or no task map: fall through to default task or mise
     if [ -n "\$DEFAULT_TASK" ]; then
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$@"
+      _shiv_exec_package_mise run -q "\$DEFAULT_TASK" "\$@"
     fi
-    exec mise -C "\$REPO" run -q "\$@"
+    _shiv_exec_package_mise run -q "\$@"
     ;;
 esac
 SCRIPT

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -78,6 +78,33 @@ TOML
   ! grep -q "^parent" "$cache"
 }
 
+@test "cache: inherited mise config override does not hide task map entries" {
+  local repo_dir parent_config cache
+  repo_dir="$BATS_TEST_TMPDIR/package-with-task-map"
+  mkdir -p "$repo_dir"
+  cat > "$repo_dir/mise.toml" <<TOML
+[tasks."hello:world"]
+description = "Say hello"
+run = "echo hi"
+TOML
+  mise trust "$repo_dir/mise.toml" 2>/dev/null
+
+  parent_config="$BATS_TEST_TMPDIR/parent-config.toml"
+  cat > "$parent_config" <<TOML
+[tasks.parent]
+description = "Parent task"
+run = "echo parent"
+TOML
+  mise trust "$parent_config" 2>/dev/null
+  export MISE_OVERRIDE_CONFIG_FILENAMES="$parent_config"
+
+  shiv_cache_task_map "package-with-task-map" "$repo_dir"
+
+  cache="$SHIV_CACHE_DIR/tasks/package-with-task-map"
+  grep -q "^hello world$" "$cache"
+  ! grep -q "^parent$" "$cache"
+}
+
 @test "cache: shiv_cache_remove deletes cache file" {
   shiv_cache_tasks "shiv" "$REPO_DIR"
   [ -f "$SHIV_CACHE_DIR/completions/shiv.cache" ]

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -51,6 +51,33 @@ setup() {
   done < "$SHIV_CACHE_DIR/completions/shiv.cache"
 }
 
+@test "cache: inherited mise config override does not hide package tasks" {
+  local repo_dir parent_config cache
+  repo_dir="$BATS_TEST_TMPDIR/package-with-tasks"
+  mkdir -p "$repo_dir"
+  cat > "$repo_dir/mise.toml" <<TOML
+[tasks.hello]
+description = "Say hello"
+run = "echo hi"
+TOML
+  mise trust "$repo_dir/mise.toml" 2>/dev/null
+
+  parent_config="$BATS_TEST_TMPDIR/parent-config.toml"
+  cat > "$parent_config" <<TOML
+[tasks.parent]
+description = "Parent task"
+run = "echo parent"
+TOML
+  mise trust "$parent_config" 2>/dev/null
+  export MISE_OVERRIDE_CONFIG_FILENAMES="$parent_config"
+
+  shiv_cache_tasks "package-with-tasks" "$repo_dir"
+
+  cache="$SHIV_CACHE_DIR/completions/package-with-tasks.cache"
+  grep -q "^hello" "$cache"
+  ! grep -q "^parent" "$cache"
+}
+
 @test "cache: shiv_cache_remove deletes cache file" {
   shiv_cache_tasks "shiv" "$REPO_DIR"
   [ -f "$SHIV_CACHE_DIR/completions/shiv.cache" ]

--- a/test/install.bats
+++ b/test/install.bats
@@ -200,6 +200,47 @@ MOCK
   grep -F "$(printf '%s\t\tinstall -q' "$repo_dir")" "$MISE_ENV_CALL_LOG"
 }
 
+@test "install: generated shim clears inherited mise config override at runtime" {
+  local repo_dir parent_config task_map
+  repo_dir="$TEST_HOME/repos/myapp"
+  mkdir -p "$repo_dir/.mise/tasks/hello"
+  git -C "$repo_dir" init -q -b main
+  git -C "$repo_dir" config user.email "test@test.com"
+  git -C "$repo_dir" config user.name "Test"
+  printf '[tools]\n' > "$repo_dir/mise.toml"
+  cat > "$repo_dir/.mise/tasks/hello/world" <<'TASK'
+#!/usr/bin/env bash
+echo package-world
+TASK
+  chmod +x "$repo_dir/.mise/tasks/hello/world"
+  git -C "$repo_dir" add .
+  git -C "$repo_dir" commit -q -m "init"
+
+  export XDG_CACHE_HOME="$TEST_HOME/.cache"
+  run_install "myapp" "$repo_dir"
+  rm -f "$SHIV_CACHE_DIR/tasks/myapp"
+
+  parent_config="$TEST_HOME/parent-config.toml"
+  cat > "$parent_config" <<'TOML'
+[tasks.parent]
+run = "echo parent-task-ran"
+TOML
+  mise trust "$parent_config" 2>/dev/null
+  export MISE_OVERRIDE_CONFIG_FILENAMES="$parent_config"
+
+  run "$SHIV_BIN_DIR/myapp" hello world
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "package-world"
+
+  task_map="$SHIV_CACHE_DIR/tasks/myapp"
+  grep -q "^hello world$" "$task_map"
+  ! grep -q "^parent$" "$task_map"
+
+  run "$SHIV_BIN_DIR/myapp" parent
+  [ "$status" -ne 0 ]
+  ! echo "$output" | grep -q "parent-task-ran"
+}
+
 @test "install: shows branch in summary card" {
   local repo_dir="$TEST_HOME/repos/branched"
   mkdir -p "$repo_dir"

--- a/test/install.bats
+++ b/test/install.bats
@@ -126,6 +126,7 @@ record_dependency_mise_calls() {
   local real_mise
   real_mise="$(command -v mise)"
   export MISE_CALL_LOG="$TEST_HOME/mise-calls.log"
+  export MISE_ENV_CALL_LOG="$TEST_HOME/mise-env-calls.log"
 
   cat > "$BATS_TEST_TMPDIR/mock-bin/mise" <<MOCK
 #!/usr/bin/env bash
@@ -133,6 +134,7 @@ if [ "\${1:-}" = "-C" ] && [ "\${2:-}" = "$REPO_DIR" ]; then
   exec "$real_mise" "\$@"
 fi
 printf '%s\t%s\n' "\$PWD" "\$*" >> "$MISE_CALL_LOG"
+printf '%s\t%s\t%s\n' "\$PWD" "\${MISE_OVERRIDE_CONFIG_FILENAMES-}" "\$*" >> "$MISE_ENV_CALL_LOG"
 exit 0
 MOCK
   chmod +x "$BATS_TEST_TMPDIR/mock-bin/mise"
@@ -181,6 +183,21 @@ MOCK
 
   grep -F "$(printf '%s\ttrust -q' "$repo_dir")" "$MISE_CALL_LOG"
   grep -F "$(printf '%s\tinstall -q' "$repo_dir")" "$MISE_CALL_LOG"
+}
+
+@test "install: dependency setup clears inherited mise config override" {
+  local repo_dir parent_config
+  repo_dir=$(create_local_repo "myapp")
+  record_dependency_mise_calls
+  parent_config="$TEST_HOME/parent-config.toml"
+  printf '[settings]\nexperimental = true\n' > "$parent_config"
+  export MISE_OVERRIDE_CONFIG_FILENAMES="$parent_config"
+
+  run bash -c "cd '$REPO_DIR' && MISE_CONFIG_ROOT='$REPO_DIR' usage_name='myapp' usage_path='$repo_dir' usage_as='' .mise/tasks/install"
+  [ "$status" -eq 0 ]
+
+  grep -F "$(printf '%s\t\ttrust -q' "$repo_dir")" "$MISE_ENV_CALL_LOG"
+  grep -F "$(printf '%s\t\tinstall -q' "$repo_dir")" "$MISE_ENV_CALL_LOG"
 }
 
 @test "install: shows branch in summary card" {

--- a/test/registry.bats
+++ b/test/registry.bats
@@ -333,49 +333,38 @@ setup() {
 # Schema validation
 # ============================================================================
 
-@test "schema: empty registry is valid" {
-  if ! command -v jsonschema &>/dev/null; then
+validate_registry_schema() {
+  if ! mise which jsonschema &>/dev/null; then
     skip "jsonschema not found"
   fi
-  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  mise x -- jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+}
+
+@test "schema: empty registry is valid" {
+  validate_registry_schema
 }
 
 @test "schema: registry with package and aliases is valid" {
-  if ! command -v jsonschema &>/dev/null; then
-    skip "jsonschema not found"
-  fi
   shiv_register "foo" "/path/to/foo" "f"
-  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  validate_registry_schema
 }
 
 @test "schema: registry without aliases is valid" {
-  if ! command -v jsonschema &>/dev/null; then
-    skip "jsonschema not found"
-  fi
   shiv_register "foo" "/path/to/foo"
-  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  validate_registry_schema
 }
 
 @test "schema: registry with ref is valid" {
-  if ! command -v jsonschema &>/dev/null; then
-    skip "jsonschema not found"
-  fi
   SHIV_REF="v1.0.0" shiv_register "foo" "/path/to/foo"
-  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  validate_registry_schema
 }
 
 @test "schema: registry with ref mode is valid" {
-  if ! command -v jsonschema &>/dev/null; then
-    skip "jsonschema not found"
-  fi
   SHIV_REF="v1.0.0" SHIV_REF_MODE="release" shiv_register "foo" "/path/to/foo"
-  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  validate_registry_schema
 }
 
 @test "schema: registry with ref and aliases is valid" {
-  if ! command -v jsonschema &>/dev/null; then
-    skip "jsonschema not found"
-  fi
   SHIV_REF="v1.0.0" shiv_register "foo" "/path/to/foo" "f"
-  jsonschema validate "$REPO_DIR/registry.schema.json" "$SHIV_REGISTRY"
+  validate_registry_schema
 }

--- a/test/resolve.bats
+++ b/test/resolve.bats
@@ -70,6 +70,32 @@ EOF
   grep -q "^secret$" "$SHIV_CACHE_DIR/tasks/fakepkg"
 }
 
+@test "task-map: cache excludes global mise tasks" {
+  local fake_dir fake_home
+  fake_dir="$TEST_HOME/package-pkg"
+  fake_home="$TEST_HOME/fake-home"
+  mkdir -p "$fake_dir/.mise/tasks" "$fake_home/.config/mise"
+  cat > "$fake_dir/mise.toml" <<'EOF'
+[tools]
+EOF
+  cat > "$fake_dir/.mise/tasks/package-task" <<'TASK'
+#!/usr/bin/env bash
+echo package
+TASK
+  chmod +x "$fake_dir/.mise/tasks/package-task"
+  cat > "$fake_home/.config/mise/config.toml" <<'EOF'
+[tasks.global-task]
+run = "echo global"
+EOF
+  HOME="$fake_home" mise trust "$fake_home/.config/mise/config.toml" 2>/dev/null
+  HOME="$fake_home" mise trust "$fake_dir/mise.toml" 2>/dev/null
+
+  HOME="$fake_home" shiv_cache_task_map "packagepkg" "$fake_dir"
+
+  grep -q "^package-task$" "$SHIV_CACHE_DIR/tasks/packagepkg"
+  ! grep -q "global-task" "$SHIV_CACHE_DIR/tasks/packagepkg"
+}
+
 @test "task-map: deep nesting translates all colons to spaces" {
   local fake_dir="$TEST_HOME/deep-pkg"
   mkdir -p "$fake_dir/.mise/tasks/a/b/c"

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -389,9 +389,7 @@ TASK
 # test "cache miss generates task map on the fly" covers that path.
 populate_task_map() {
   local name="$1" repo_dir="$2"
-  mkdir -p "$SHIV_CACHE_DIR/tasks"
-  mise tasks --json --hidden -C "$repo_dir" 2>/dev/null \
-    | jq -r '.[].name | gsub(":"; " ")' > "$SHIV_CACHE_DIR/tasks/$name"
+  SHIV_SKIP_CACHE= shiv_cache_task_map "$name" "$repo_dir"
 }
 
 @test "shim: spaces resolve to colons end-to-end" {
@@ -477,6 +475,33 @@ populate_task_map() {
   [[ "$output" == *"DEV_TEST_UNIT"* ]]
 
   [ -f "$SHIV_CACHE_DIR/tasks/mytool" ]
+}
+
+@test "shim: cache miss and execution ignore inherited mise config override" {
+  local repo_dir parent_config
+  repo_dir=$(create_resolve_repo "mytool")
+  shiv install mytool "$repo_dir" 2>/dev/null
+
+  parent_config="$TEST_HOME/parent-config.toml"
+  cat > "$parent_config" <<'TOML'
+[tasks.parent-only]
+description = "Parent task should not leak"
+run = "echo PARENT_ONLY"
+TOML
+  mise trust "$parent_config" 2>/dev/null
+
+  [ ! -f "$SHIV_CACHE_DIR/tasks/mytool" ]
+
+  run env -u SHIV_SKIP_CACHE \
+    MISE_OVERRIDE_CONFIG_FILENAMES="$parent_config" \
+    XDG_CACHE_HOME="$TEST_HOME/.cache" \
+    "$SHIV_BIN_DIR/mytool" dev test unit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEV_TEST_UNIT"* ]]
+  [[ "$output" != *"PARENT_ONLY"* ]]
+
+  grep -q "^dev test unit$" "$SHIV_CACHE_DIR/tasks/mytool"
+  ! grep -q "parent-only" "$SHIV_CACHE_DIR/tasks/mytool"
 }
 
 @test "shim: unresolved input falls through to mise" {


### PR DESCRIPTION
## Summary
- clear inherited `MISE_OVERRIDE_CONFIG_FILENAMES` before installing a package repo's own mise dependencies
- clear the same override when building package task caches
- make completion-cache generation non-fatal like task-map cache generation, and filter global mise tasks out of package caches

## Why
`vfox-shiv` bootstraps shiv with `MISE_OVERRIDE_CONFIG_FILENAMES=mise.prod.toml` so shiv uses runtime-only dependencies. That env leaked into child package handling. A fresh `shiv:notes = "0.8"` install now resolves to `notes@v0.8.17`, but task-cache generation failed because mise saw the package task files as untrusted under the wrong config context.

## Validation
- `bash -n .mise/tasks/install lib/cache.sh`
- `git diff --check`
- `mise run test test/install.bats test/completions.bats`
- `mise run test test/resolve.bats --filter 'task-map|empty output'`
- manual smoke: local shiv install of `notes@v0.8.17` with `MISE_OVERRIDE_CONFIG_FILENAMES=mise.prod.toml` succeeded and produced notes completion/task caches
- full `mise run test` is degraded locally in `doctor.bats` and `registry.bats`; the same suites fail on a clean `origin/main` worktree in this environment. `registry.bats` is picking up a different `jsonschema` CLI interface from `/Users/rikonor/.venv-vllm-metal/bin/jsonschema`.
