### PR TITLE
fix: isolate shim runtime from mise override

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 277 passing](https://img.shields.io/badge/tests-277%20passing-brightgreen?style=flat)
+![tests: 279 passing](https://img.shields.io/badge/tests-279%20passing-brightgreen?style=flat)
 ![packages: 45](https://img.shields.io/badge/packages-45-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -148,7 +148,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 277 tests across 14 suites. Completion tests run separately.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 279 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -91,6 +91,11 @@ _shiv_check_cwd() {
   fi
 }
 
+_shiv_mise() {
+  unset MISE_OVERRIDE_CONFIG_FILENAMES
+  exec mise -C "\$REPO" "\$@"
+}
+
 # NOTE: the mise tasks | jq pipeline below duplicates shiv_cache_task_map()
 # in lib/cache.sh (shim self-containment). If you change the format, update both.
 _shiv_ensure_task_map() {
@@ -101,8 +106,10 @@ _shiv_ensure_task_map() {
   fi
   mkdir -p "\$(dirname "\$SHIV_TASK_MAP")"
   local tmp="\$SHIV_TASK_MAP.tmp"
-  if ! mise tasks --json --hidden -C "\$REPO" 2>/dev/null \\
-    | jq -r '.[].name | gsub(":"; " ")' > "\$tmp" 2>/dev/null; then
+  if ! (
+    unset MISE_OVERRIDE_CONFIG_FILENAMES
+    mise tasks --json --hidden -C "\$REPO" 2>/dev/null
+  ) | jq -r '.[].name | gsub(":"; " ")' > "\$tmp" 2>/dev/null; then
     rm -f "\$tmp"
     return 0
   fi
@@ -127,8 +134,10 @@ _shiv_render_tasks() {
   local tmp repo_prefix
   tmp=\$(mktemp)
   repo_prefix="\$(cd "\$REPO" && pwd -P)/"
-  if ! mise -C "\$REPO" tasks --local --json 2>/dev/null \
-    | jq -r --arg repo_prefix "\$repo_prefix" '[.[] | select(.hide != true) | select(((.source // .file // "") | startswith(\$repo_prefix))) | (.name | split(":")) as \$p | {
+  if ! (
+    unset MISE_OVERRIDE_CONFIG_FILENAMES
+    mise -C "\$REPO" tasks --local --json 2>/dev/null
+  ) | jq -r --arg repo_prefix "\$repo_prefix" '[.[] | select(.hide != true) | select(((.source // .file // "") | startswith(\$repo_prefix))) | (.name | split(":")) as \$p | {
         group: (if (\$p | length) > 1 then \$p[0] else "root" end),
         task: (if (\$p | length) > 1 then (\$p[1:] | join(":")) else .name end),
         aliases: ((.aliases // []) | join(", ")),
@@ -166,7 +175,7 @@ _shiv_render_tasks() {
 
 _shiv_handle_tasks() {
   if [ "\$HAS_TASKS_TASK" = "true" ]; then
-    exec mise -C "\$REPO" run -q "\$@"
+    _shiv_mise run -q "\$@"
   fi
   _shiv_render_tasks
   local rc=\$?
@@ -181,7 +190,7 @@ _shiv_handle_help() {
   # Package-owned help wins. This lets tools expose richer help than the
   # generic mise task list while keeping the shim-level interception.
   if [ "\$HAS_HELP_TASK" = "true" ]; then
-    exec mise -C "\$REPO" run -q help
+    _shiv_mise run -q help
   fi
 
   # Single-command tools (.mise/tasks/<name>) should show the command help,
@@ -189,9 +198,9 @@ _shiv_handle_help() {
   # menus/catch-alls where task-list help is still the safer default.
   if [ -n "\$DEFAULT_TASK" ] && [ "\$DEFAULT_TASK" != "_default" ]; then
     if [ "\$help_arg" = "help" ]; then
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" help
+      _shiv_mise run -q "\$DEFAULT_TASK" help
     else
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$help_arg"
+      _shiv_mise run -q "\$DEFAULT_TASK" "\$help_arg"
     fi
   fi
 
@@ -229,7 +238,7 @@ case "\${1:-}" in
     # --- Default task handling ---
     # No args: run default task directly.
     if [ -n "\$DEFAULT_TASK" ] && [ -z "\${1:-}" ]; then
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK"
+      _shiv_mise run -q "\$DEFAULT_TASK"
     fi
 
     # "--" as first arg: explicit disambiguation — send everything
@@ -237,9 +246,9 @@ case "\${1:-}" in
     if [ -n "\$DEFAULT_TASK" ] && [ "\${1:-}" = "--" ]; then
       shift
       if [ \$# -gt 0 ]; then
-        exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$@"
+        _shiv_mise run -q "\$DEFAULT_TASK" "\$@"
       else
-        exec mise -C "\$REPO" run -q "\$DEFAULT_TASK"
+        _shiv_mise run -q "\$DEFAULT_TASK"
       fi
     fi
 
@@ -271,18 +280,18 @@ case "\${1:-}" in
       # Guard: only expand SHIV_RESOLVED_ARGS when non-empty.
       # bash <4.4 treats "\${empty_array[@]}" as unbound under set -u.
       if [ \${#SHIV_RESOLVED_ARGS[@]} -gt 0 ]; then
-        exec mise -C "\$REPO" run -q "\$SHIV_RESOLVED_TASK" "\${SHIV_RESOLVED_ARGS[@]}"
+        _shiv_mise run -q "\$SHIV_RESOLVED_TASK" "\${SHIV_RESOLVED_ARGS[@]}"
       else
-        exec mise -C "\$REPO" run -q "\$SHIV_RESOLVED_TASK"
+        _shiv_mise run -q "\$SHIV_RESOLVED_TASK"
       fi
     elif [ "\$_shiv_rc" -eq 1 ]; then
       exit 1  # ambiguous — error already printed to stderr
     fi
     # rc=2 or no task map: fall through to default task or mise
     if [ -n "\$DEFAULT_TASK" ]; then
-      exec mise -C "\$REPO" run -q "\$DEFAULT_TASK" "\$@"
+      _shiv_mise run -q "\$DEFAULT_TASK" "\$@"
     fi
-    exec mise -C "\$REPO" run -q "\$@"
+    _shiv_mise run -q "\$@"
     ;;
 esac
 SCRIPT

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -78,6 +78,33 @@ TOML
   ! grep -q "^parent" "$cache"
 }
 
+@test "cache: inherited mise config override does not hide task map entries" {
+  local repo_dir parent_config cache
+  repo_dir="$BATS_TEST_TMPDIR/package-with-task-map"
+  mkdir -p "$repo_dir"
+  cat > "$repo_dir/mise.toml" <<TOML
+[tasks."hello:world"]
+description = "Say hello"
+run = "echo hi"
+TOML
+  mise trust "$repo_dir/mise.toml" 2>/dev/null
+
+  parent_config="$BATS_TEST_TMPDIR/parent-config.toml"
+  cat > "$parent_config" <<TOML
+[tasks.parent]
+description = "Parent task"
+run = "echo parent"
+TOML
+  mise trust "$parent_config" 2>/dev/null
+  export MISE_OVERRIDE_CONFIG_FILENAMES="$parent_config"
+
+  shiv_cache_task_map "package-with-task-map" "$repo_dir"
+
+  cache="$SHIV_CACHE_DIR/tasks/package-with-task-map"
+  grep -q "^hello world$" "$cache"
+  ! grep -q "^parent$" "$cache"
+}
+
 @test "cache: shiv_cache_remove deletes cache file" {
   shiv_cache_tasks "shiv" "$REPO_DIR"
   [ -f "$SHIV_CACHE_DIR/completions/shiv.cache" ]

--- a/test/install.bats
+++ b/test/install.bats
@@ -200,6 +200,47 @@ MOCK
   grep -F "$(printf '%s\t\tinstall -q' "$repo_dir")" "$MISE_ENV_CALL_LOG"
 }
 
+@test "install: generated shim clears inherited mise config override at runtime" {
+  local repo_dir parent_config task_map
+  repo_dir="$TEST_HOME/repos/myapp"
+  mkdir -p "$repo_dir/.mise/tasks/hello"
+  git -C "$repo_dir" init -q -b main
+  git -C "$repo_dir" config user.email "test@test.com"
+  git -C "$repo_dir" config user.name "Test"
+  printf '[tools]\n' > "$repo_dir/mise.toml"
+  cat > "$repo_dir/.mise/tasks/hello/world" <<'TASK'
+#!/usr/bin/env bash
+echo package-world
+TASK
+  chmod +x "$repo_dir/.mise/tasks/hello/world"
+  git -C "$repo_dir" add .
+  git -C "$repo_dir" commit -q -m "init"
+
+  export XDG_CACHE_HOME="$TEST_HOME/.cache"
+  run_install "myapp" "$repo_dir"
+  rm -f "$SHIV_CACHE_DIR/tasks/myapp"
+
+  parent_config="$TEST_HOME/parent-config.toml"
+  cat > "$parent_config" <<'TOML'
+[tasks.parent]
+run = "echo parent-task-ran"
+TOML
+  mise trust "$parent_config" 2>/dev/null
+  export MISE_OVERRIDE_CONFIG_FILENAMES="$parent_config"
+
+  run "$SHIV_BIN_DIR/myapp" hello world
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "package-world"
+
+  task_map="$SHIV_CACHE_DIR/tasks/myapp"
+  grep -q "^hello world$" "$task_map"
+  ! grep -q "^parent$" "$task_map"
+
+  run "$SHIV_BIN_DIR/myapp" parent
+  [ "$status" -ne 0 ]
+  ! echo "$output" | grep -q "parent-task-ran"
+}
+
 @test "install: shows branch in summary card" {
   local repo_dir="$TEST_HOME/repos/branched"
   mkdir -p "$repo_dir"


### PR DESCRIPTION
## Summary

- clear `MISE_OVERRIDE_CONFIG_FILENAMES` in generated shim runtime mise calls, not only install/cache setup
- keep lazy task-map and task-list rendering isolated from caller override config
- add regression coverage for runtime shim invocation and task-map cache generation under an inherited override
- regenerate README test count

## Validation

- `mise run test` (279/279)
- `mise run test install completions` (68/68)
- `mise run registry:validate`
- `mise exec -- readme build --check`
- `codebase lint "$PWD"`
- `git diff --check origin/main...HEAD`
- `bash -n lib/shim.sh lib/cache.sh .mise/tasks/install`
