### PR TITLE
Fix mise-managed shim task-map isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 281 passing](https://img.shields.io/badge/tests-281%20passing-brightgreen?style=flat)
-![packages: 46](https://img.shields.io/badge/packages-46-blue?style=flat)
+![tests: 283 passing](https://img.shields.io/badge/tests-283%20passing-brightgreen?style=flat)
+![packages: 48](https://img.shields.io/badge/packages-48-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -148,7 +148,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 281 tests across 14 suites. Completion tests run separately.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 283 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 283 passing](https://img.shields.io/badge/tests-283%20passing-brightgreen?style=flat)
+![tests: 284 passing](https://img.shields.io/badge/tests-284%20passing-brightgreen?style=flat)
 ![packages: 48](https://img.shields.io/badge/packages-48-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -148,7 +148,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 283 tests across 14 suites. Completion tests run separately.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 284 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -30,8 +30,9 @@ shiv_caller_pwd_var_name() {
 shiv_create_shim() {
   local name="$1" repo_dir="$2"
   local default_task=""
-  local caller_pwd_var
+  local caller_pwd_var task_map_quoted
   caller_pwd_var=$(shiv_caller_pwd_var_name "$name")
+  task_map_quoted=$(shiv_shell_quote "$SHIV_CACHE_DIR/tasks/$name")
 
   # At install time, detect a default task for single-command tools.
   # Checks .mise/tasks/<name> first, then .mise/tasks/_default.
@@ -71,7 +72,7 @@ REPO="$repo_dir"
 DEFAULT_TASK="${default_task}"
 HAS_TASKS_TASK="${has_tasks_task}"
 HAS_HELP_TASK="${has_help_task}"
-SHIV_TASK_MAP="\${XDG_CACHE_HOME:-\$HOME/.cache}/shiv/tasks/$name"
+SHIV_TASK_MAP=$task_map_quoted
 
 _shiv_check_repo() {
   if [ ! -d "\$REPO" ]; then

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -403,6 +403,48 @@ populate_task_map() {
   [[ "$output" == *"DEV_TEST_UNIT"* ]]
 }
 
+@test "shim: install-local task map ignores conflicting runtime XDG cache" {
+  local repo_dir runtime_cache
+  repo_dir=$(create_resolve_repo "mytool")
+  shiv install mytool "$repo_dir" 2>/dev/null
+  populate_task_map "mytool" "$repo_dir"
+
+  runtime_cache="$TEST_HOME/runtime-cache"
+  mkdir -p "$runtime_cache/shiv/tasks"
+  printf '%s\n' "stale task" > "$runtime_cache/shiv/tasks/mytool"
+
+  run env XDG_CACHE_HOME="$runtime_cache" "$SHIV_BIN_DIR/mytool" dev test unit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEV_TEST_UNIT"* ]]
+}
+
+@test "shim: same package shims keep separate install-local task maps" {
+  local repo_dir first_bin first_cache second_bin second_cache runtime_cache
+  repo_dir=$(create_resolve_repo "mytool")
+  first_bin="$TEST_HOME/versions/one/bin"
+  first_cache="$TEST_HOME/versions/one/cache"
+  second_bin="$TEST_HOME/versions/two/bin"
+  second_cache="$TEST_HOME/versions/two/cache"
+  runtime_cache="$TEST_HOME/runtime-cache"
+
+  SHIV_BIN_DIR="$first_bin" SHIV_CACHE_DIR="$first_cache" shiv_create_shim "mytool" "$repo_dir"
+  mkdir -p "$first_cache/tasks"
+  printf '%s\n' "dev test unit" > "$first_cache/tasks/mytool"
+
+  SHIV_BIN_DIR="$second_bin" SHIV_CACHE_DIR="$second_cache" shiv_create_shim "mytool" "$repo_dir"
+  mkdir -p "$second_cache/tasks" "$runtime_cache/shiv/tasks"
+  printf '%s\n' "greet loud" > "$second_cache/tasks/mytool"
+  printf '%s\n' "stale task" > "$runtime_cache/shiv/tasks/mytool"
+
+  run env XDG_CACHE_HOME="$runtime_cache" "$first_bin/mytool" dev test unit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEV_TEST_UNIT"* ]]
+
+  run env XDG_CACHE_HOME="$runtime_cache" "$second_bin/mytool" greet loud
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GREET_LOUD"* ]]
+}
+
 @test "shim: tasks groups colon-namespaced tasks" {
   local repo_dir
   repo_dir=$(create_resolve_repo "mytool")
@@ -462,19 +504,21 @@ populate_task_map() {
   [[ "$output" == "GREET_LOUD " ]] || [[ "$output" == "GREET_LOUD" ]]
 }
 
-@test "shim: cache miss generates task map on the fly" {
-  local repo_dir
+@test "shim: cache miss generates task map in install-local cache" {
+  local repo_dir runtime_cache
   repo_dir=$(create_resolve_repo "mytool")
   shiv install mytool "$repo_dir" 2>/dev/null
 
+  runtime_cache="$TEST_HOME/runtime-cache"
   [ ! -f "$SHIV_CACHE_DIR/tasks/mytool" ]
+  [ ! -f "$runtime_cache/shiv/tasks/mytool" ]
 
-  # The shim uses XDG_CACHE_HOME (not SHIV_CACHE_DIR) for task maps.
-  run env -u SHIV_SKIP_CACHE XDG_CACHE_HOME="$TEST_HOME/.cache" "$SHIV_BIN_DIR/mytool" dev test unit
+  run env -u SHIV_SKIP_CACHE XDG_CACHE_HOME="$runtime_cache" "$SHIV_BIN_DIR/mytool" dev test unit
   [ "$status" -eq 0 ]
   [[ "$output" == *"DEV_TEST_UNIT"* ]]
 
   [ -f "$SHIV_CACHE_DIR/tasks/mytool" ]
+  [ ! -f "$runtime_cache/shiv/tasks/mytool" ]
 }
 
 @test "shim: cache miss and execution ignore inherited mise config override" {

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -445,6 +445,35 @@ populate_task_map() {
   [[ "$output" == *"GREET_LOUD"* ]]
 }
 
+@test "shim: default global cache stays fixed at its generation-time XDG path" {
+  local repo_dir generation_xdg runtime_xdg task_map
+  repo_dir=$(create_resolve_repo "mytool")
+  generation_xdg="$TEST_HOME/generation-cache"
+  runtime_xdg="$TEST_HOME/runtime-cache"
+
+  unset SHIV_CACHE_DIR
+  export XDG_CACHE_HOME="$generation_xdg"
+  source "$REPO_DIR/lib/cache.sh"
+  [ "$SHIV_CACHE_DIR" = "$generation_xdg/shiv" ]
+
+  shiv_create_shim "mytool" "$repo_dir"
+  task_map="$generation_xdg/shiv/tasks/mytool"
+  mkdir -p "$(dirname "$task_map")" "$runtime_xdg/shiv/tasks"
+  printf '%s\n' "dev test unit" > "$task_map"
+  printf '%s\n' "stale task" > "$runtime_xdg/shiv/tasks/mytool"
+
+  run env -u SHIV_SKIP_CACHE XDG_CACHE_HOME="$runtime_xdg" "$SHIV_BIN_DIR/mytool" dev test unit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEV_TEST_UNIT"* ]]
+
+  rm -f "$task_map"
+  run env -u SHIV_SKIP_CACHE XDG_CACHE_HOME="$runtime_xdg" "$SHIV_BIN_DIR/mytool" dev test unit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEV_TEST_UNIT"* ]]
+  grep -q '^dev test unit$' "$task_map"
+  grep -q '^stale task$' "$runtime_xdg/shiv/tasks/mytool"
+}
+
 @test "shim: tasks groups colon-namespaced tasks" {
   local repo_dir
   repo_dir=$(create_resolve_repo "mytool")


### PR DESCRIPTION
## Summary

- bake each package's install-time task-map path into its generated shim
- keep same-named package versions isolated from conflicting runtime/global maps
- regenerate cache misses in the same install-local cache used during installation
- cover traditional global-cache resolution and generation-time XDG ownership
- refresh generated README counts after adding coverage

Closes #146.

## Validation

- `mise run test` — 284/284
- `mise run test shim` — 34/34
- configured codebase lints — 7/7
- `mise exec -- readme build --check`
- `git diff --check`
- new traditional-global regression fails against unmodified `v0.3.5` and passes on this branch

## Degraded check

`mise run doctor` validates the registry, bin directory, and 34 packages, then exits nonzero for an unrelated pre-existing legacy `whora` registration whose repo path `/tmp/iris.d/whora` is missing. This PR does not modify that registration.
