### PR TITLE
registry: add shitshow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 ![tests: 284 passing](https://img.shields.io/badge/tests-284%20passing-brightgreen?style=flat)
-![packages: 48](https://img.shields.io/badge/packages-48-blue?style=flat)
+![packages: 49](https://img.shields.io/badge/packages-49-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>

--- a/sources.json
+++ b/sources.json
@@ -34,6 +34,7 @@
   "sessions": "KnickKnackLabs/sessions",
   "shell": "KnickKnackLabs/shell",
   "shimmer": "KnickKnackLabs/shimmer",
+  "shitshow": "KnickKnackLabs/shitshow",
   "shiv": "KnickKnackLabs/shiv",
   "sms": "KnickKnackLabs/sms",
   "sphincters": "KnickKnackLabs/sphincters",


### PR DESCRIPTION
## Summary

- register `KnickKnackLabs/shitshow` in the default shiv package index
- regenerate the package-count badge from 48 to 49

Shitshow `v0.1.0` is already published as a signed annotated tag at `c4a9177`.

## Validation

- `mise run test` — 284/284 BATS passing
- `mise exec -- codebase lint "$PWD"` — all 7 configured rules passing
- `mise exec -- readme build --check`
- exact source mapping, alphabetical key order, and 49-package count checks
- `git diff --check`

## Boundary

This PR only registers the released package. It does not release shiv. After merge, the planned next step is a separate signed shiv `v0.3.7` patch release followed by isolated direct-shiv and `shiv:shitshow = "0.1"` consumer smokes.
