### PR TITLE
feat: report package versions from generated shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 289 passing](https://img.shields.io/badge/tests-289%20passing-brightgreen?style=flat)
+![tests: 290 passing](https://img.shields.io/badge/tests-290%20passing-brightgreen?style=flat)
 ![packages: 49](https://img.shields.io/badge/packages-49-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -151,7 +151,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 289 tests across 14 suites. Completion tests run separately.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 290 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 290 passing](https://img.shields.io/badge/tests-290%20passing-brightgreen?style=flat)
+![tests: 291 passing](https://img.shields.io/badge/tests-291%20passing-brightgreen?style=flat)
 ![packages: 49](https://img.shields.io/badge/packages-49-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -151,7 +151,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 290 tests across 14 suites. Completion tests run separately.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 291 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 284 passing](https://img.shields.io/badge/tests-284%20passing-brightgreen?style=flat)
+![tests: 289 passing](https://img.shields.io/badge/tests-289%20passing-brightgreen?style=flat)
 ![packages: 49](https://img.shields.io/badge/packages-49-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -24,6 +24,9 @@ shiv install shimmer
 
 # Use it — spaces work as namespace separators
 shimmer agent message k7r2 "hello"
+
+# Check the installed version
+shimmer --version
 
 # See what's installed
 shiv list
@@ -47,7 +50,7 @@ When you run `shiv install foo`, shiv:
 4. Generates a shim at `~/.local/bin/foo`
 5. Registers the package in `~/.config/shiv/registry.json`
 
-The shim is a bash script that forwards commands to `mise -C <repo> run`. It exports a package-specific caller variable (for example, `SHIMMER_CALLER_PWD`) so tools know where you invoked them, translates space-separated arguments to colon-joined task names (`agent message` → `agent:message`), and provides tab completions for all available tasks.
+The shim is a bash script that forwards commands to `mise -C <repo> run`. It exports a package-specific caller variable (for example, `SHIMMER_CALLER_PWD`) so tools know where you invoked them, translates space-separated arguments to colon-joined task names (`agent message` → `agent:message`), reports the package's exact tag or commit through `--version`, and provides tab completions for all available tasks.
 
 ## Install
 
@@ -148,7 +151,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 284 tests across 14 suites. Completion tests run separately.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 289 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/README.tsx
+++ b/README.tsx
@@ -67,6 +67,9 @@ shiv install shimmer
 # Use it — spaces work as namespace separators
 shimmer agent message k7r2 "hello"
 
+# Check the installed version
+shimmer --version
+
 # See what's installed
 shiv list
 
@@ -100,6 +103,7 @@ shiv doctor`}</CodeBlock>
         a package-specific caller variable (for example, <Code>SHIMMER_CALLER_PWD</Code>) so tools know where you invoked them,
         translates space-separated arguments to colon-joined task names
         (<Code>agent message</Code> → <Code>agent:message</Code>),
+        reports the package's exact tag or commit through <Code>--version</Code>,
         and provides tab completions for all available tasks.
       </Paragraph>
     </Section>

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -225,6 +225,27 @@ _shiv_handle_help() {
   _shiv_handle_tasks tasks
 }
 
+_shiv_handle_version() {
+  local version branch updated
+
+  if ! version=\$(git -C "\$REPO" describe --tags --exact-match HEAD 2>/dev/null); then
+    version=\$(git -C "\$REPO" rev-parse --short HEAD 2>/dev/null || printf 'unknown')
+  fi
+
+  if [ "\$version" = "unknown" ]; then
+    branch="unknown"
+    updated="unknown"
+  else
+    if [ -n "\$(git -C "\$REPO" status --porcelain 2>/dev/null)" ]; then
+      version="\${version}*"
+    fi
+    branch=\$(git -C "\$REPO" symbolic-ref --quiet --short HEAD 2>/dev/null || printf 'detached')
+    updated=\$(git -C "\$REPO" log -1 --format='%cd' --date=relative 2>/dev/null || printf 'unknown')
+  fi
+
+  printf '%s %s (branch: %s, updated: %s)\n' "$name" "\$version" "\$branch" "\$updated"
+}
+
 SCRIPT
 
   {
@@ -248,6 +269,9 @@ _shiv_check_cwd "\$@"
 case "\${1:-}" in
   --help|-h|help)
     _shiv_handle_help "\${1:-help}"
+    ;;
+  --version)
+    _shiv_handle_version
     ;;
   tasks)
     _shiv_handle_tasks "\$@"

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -226,7 +226,13 @@ _shiv_handle_help() {
 }
 
 _shiv_handle_version() {
-  local version branch updated git_prefix
+  local version branch updated git_prefix git_var
+
+  # Git exports repository-selection variables to hooks. Clear them before
+  # inspecting the package so caller metadata cannot override git -C.
+  while IFS= read -r git_var; do
+    [ -n "\$git_var" ] && unset "\$git_var"
+  done < <(git rev-parse --local-env-vars 2>/dev/null)
 
   # git -C searches parent directories. Require the package itself to be the
   # worktree root so a non-Git local package cannot inherit unrelated metadata.

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -226,9 +226,13 @@ _shiv_handle_help() {
 }
 
 _shiv_handle_version() {
-  local version branch updated
+  local version branch updated git_prefix
 
-  if ! version=\$(git -C "\$REPO" describe --tags --exact-match HEAD 2>/dev/null); then
+  # git -C searches parent directories. Require the package itself to be the
+  # worktree root so a non-Git local package cannot inherit unrelated metadata.
+  if ! git_prefix=\$(git -C "\$REPO" rev-parse --show-prefix 2>/dev/null) || [ -n "\$git_prefix" ]; then
+    version="unknown"
+  elif ! version=\$(git -C "\$REPO" describe --tags --exact-match HEAD 2>/dev/null); then
     version=\$(git -C "\$REPO" rev-parse --short HEAD 2>/dev/null || printf 'unknown')
   fi
 

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -193,6 +193,24 @@ TASK
   [ "$output" = "myapp unknown (branch: unknown, updated: unknown)" ]
 }
 
+@test "shim: --version ignores inherited Git repository environment" {
+  local parent_dir="$TEST_HOME/repos/parent" repo_dir short
+  repo_dir=$(create_caller_repo "myapp")
+  short=$(git -C "$repo_dir" rev-parse --short HEAD)
+  mkdir -p "$parent_dir"
+  git -C "$parent_dir" init -q -b unrelated
+  git -C "$parent_dir" config user.email "test@test.com"
+  git -C "$parent_dir" config user.name "Test"
+  touch "$parent_dir/tracked"
+  git -C "$parent_dir" add tracked
+  git -C "$parent_dir" commit -q -m "init"
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run env GIT_DIR="$parent_dir/.git" "$SHIV_BIN_DIR/myapp" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" == "myapp $short (branch: main, updated: "*" ago)" ]]
+}
+
 # ============================================================================
 # tasks interception
 # ============================================================================

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -117,6 +117,66 @@ TASK
 }
 
 # ============================================================================
+# version interception
+# ============================================================================
+
+@test "shim: --version shows the exact tag, branch, and commit age" {
+  local repo_dir
+  repo_dir=$(create_caller_repo "myapp")
+  git -C "$repo_dir" tag --no-sign v1.2.3
+  git -C "$repo_dir" -c advice.detachedHead=false checkout --detach v1.2.3
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" == "myapp v1.2.3 (branch: detached, updated: "*" ago)" ]]
+}
+
+@test "shim: --version falls back to the short commit" {
+  local repo_dir short
+  repo_dir=$(create_caller_repo "myapp")
+  short=$(git -C "$repo_dir" rev-parse --short HEAD)
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" == "myapp $short (branch: main, updated: "*" ago)" ]]
+}
+
+@test "shim: --version marks a dirty checkout" {
+  local repo_dir short
+  repo_dir=$(create_caller_repo "myapp")
+  short=$(git -C "$repo_dir" rev-parse --short HEAD)
+  touch "$repo_dir/uncommitted.txt"
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" == "myapp $short* (branch: main, updated: "*" ago)" ]]
+}
+
+@test "shim: --version is handled before a named default task" {
+  local repo_dir
+  repo_dir=$(create_named_default_repo "myapp")
+  shiv install myapp "$repo_dir" 2>/dev/null
+
+  run "$SHIV_BIN_DIR/myapp" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" == "myapp "*" (branch: main, updated: "*" ago)" ]]
+  [[ "$output" != *"NAMED_DEFAULT"* ]]
+}
+
+@test "shim: --version reports unknown metadata outside Git" {
+  local repo_dir="$TEST_HOME/repos/myapp"
+  mkdir -p "$repo_dir"
+  shiv_create_shim "myapp" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/myapp" --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "myapp unknown (branch: unknown, updated: unknown)" ]
+}
+
+# ============================================================================
 # tasks interception
 # ============================================================================
 

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -176,6 +176,23 @@ TASK
   [ "$output" = "myapp unknown (branch: unknown, updated: unknown)" ]
 }
 
+@test "shim: --version does not inherit Git metadata from a parent checkout" {
+  local parent_dir="$TEST_HOME/repos/parent" repo_dir="$TEST_HOME/repos/parent/myapp"
+  mkdir -p "$parent_dir"
+  git -C "$parent_dir" init -q -b unrelated
+  git -C "$parent_dir" config user.email "test@test.com"
+  git -C "$parent_dir" config user.name "Test"
+  touch "$parent_dir/tracked"
+  git -C "$parent_dir" add tracked
+  git -C "$parent_dir" commit -q -m "init"
+  mkdir -p "$repo_dir"
+  shiv_create_shim "myapp" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/myapp" --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "myapp unknown (branch: unknown, updated: unknown)" ]
+}
+
 # ============================================================================
 # tasks interception
 # ============================================================================


### PR DESCRIPTION
## Summary

- intercept `--version` in every generated package shim
- report the exact Git tag or short commit, dirty state, branch, and commit age
- handle detached release installs and non-Git local packages honestly
- document the shared version command

Closes #85

## Validation

- `mise run test` (289 tests)
- `mise exec -- codebase lint`
- `bash -n lib/shim.sh`
- `mise exec -- readme build --check`
- generated a real shim from the branch and ran `shiv --version`
