### PR TITLE
fix: isolate shim version metadata to package repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![tests: 289 passing](https://img.shields.io/badge/tests-289%20passing-brightgreen?style=flat)
+![tests: 290 passing](https://img.shields.io/badge/tests-290%20passing-brightgreen?style=flat)
 ![packages: 49](https://img.shields.io/badge/packages-49-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
@@ -151,7 +151,7 @@ cd shiv && mise trust && mise install
 mise run test
 ```
 
-Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 289 tests across 14 suites. Completion tests run separately.
+Tests use [BATS](https://github.com/bats-core/bats-core) — the default run covers 290 tests across 14 suites. Completion tests run separately.
 
 <div align="center">
 

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -226,9 +226,13 @@ _shiv_handle_help() {
 }
 
 _shiv_handle_version() {
-  local version branch updated
+  local version branch updated git_prefix
 
-  if ! version=\$(git -C "\$REPO" describe --tags --exact-match HEAD 2>/dev/null); then
+  # git -C searches parent directories. Require the package itself to be the
+  # worktree root so a non-Git local package cannot inherit unrelated metadata.
+  if ! git_prefix=\$(git -C "\$REPO" rev-parse --show-prefix 2>/dev/null) || [ -n "\$git_prefix" ]; then
+    version="unknown"
+  elif ! version=\$(git -C "\$REPO" describe --tags --exact-match HEAD 2>/dev/null); then
     version=\$(git -C "\$REPO" rev-parse --short HEAD 2>/dev/null || printf 'unknown')
   fi
 

--- a/test/shim.bats
+++ b/test/shim.bats
@@ -176,6 +176,23 @@ TASK
   [ "$output" = "myapp unknown (branch: unknown, updated: unknown)" ]
 }
 
+@test "shim: --version does not inherit Git metadata from a parent checkout" {
+  local parent_dir="$TEST_HOME/repos/parent" repo_dir="$TEST_HOME/repos/parent/myapp"
+  mkdir -p "$parent_dir"
+  git -C "$parent_dir" init -q -b unrelated
+  git -C "$parent_dir" config user.email "test@test.com"
+  git -C "$parent_dir" config user.name "Test"
+  touch "$parent_dir/tracked"
+  git -C "$parent_dir" add tracked
+  git -C "$parent_dir" commit -q -m "init"
+  mkdir -p "$repo_dir"
+  shiv_create_shim "myapp" "$repo_dir"
+
+  run "$SHIV_BIN_DIR/myapp" --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "myapp unknown (branch: unknown, updated: unknown)" ]
+}
+
 # ============================================================================
 # tasks interception
 # ============================================================================


### PR DESCRIPTION
## Summary

- require a generated shim's package path to be the Git worktree root before reporting Git metadata
- keep linked worktree roots valid while preventing non-Git local packages from inheriting an unrelated parent checkout's commit, branch, and dirty state
- add the missing nested non-Git regression and refresh the generated README test count

Fix-it for #151.

## Validation

- `mise run test shim` (40/40)
- `env -u MISE_DATA_DIR mise run test` (290/290)
- metadata smoke: exact tag, dirty exact tag, detached commit, standalone non-Git package, nested non-Git package, linked worktree
- `mise exec -- codebase lint`
- `bash -n lib/shim.sh`
- `mise exec -- readme build --check`

The first unmodified full-suite run exposed eight pre-existing `test/shell.bats` failures because this hosted environment exports `MISE_DATA_DIR`; the same suite passed 290/290 with that ambient override cleared, matching CI's environment.
