### PR TITLE
feat: add safe reshim workflow

### DIFF
--- a/.mise/tasks/reshim
+++ b/.mise/tasks/reshim
@@ -4,6 +4,13 @@ set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/shim.sh"
 
+# Git exports repository-selection variables to hooks. Clear them before
+# inspecting registered packages so caller metadata cannot override git -C.
+git_local_env_vars=$(git rev-parse --local-env-vars 2>/dev/null)
+while IFS= read -r git_var; do
+  [ -n "$git_var" ] && unset "$git_var"
+done <<< "$git_local_env_vars"
+
 shiv_init_registry
 
 COUNT=$(jq 'length' "$SHIV_REGISTRY")

--- a/.mise/tasks/reshim
+++ b/.mise/tasks/reshim
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#MISE description="Regenerate shims and caches for every clean registered package"
+set -euo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/shim.sh"
+
+shiv_init_registry
+
+COUNT=$(jq 'length' "$SHIV_REGISTRY")
+if [ "$COUNT" -eq 0 ]; then
+  echo "No tools registered."
+  exit 0
+fi
+
+SEP='|'
+RESULTS=()
+
+add_result() {
+  RESULTS+=("$1${SEP}$2${SEP}$3")
+}
+
+reshim_one() {
+  local name="$1" repo="$2"
+  local dirty_output
+
+  if [ ! -d "$repo" ]; then
+    add_result "$name" "✗" "repo not found at $repo"
+    echo "  ✗ $name — repo not found at $repo"
+    return 1
+  fi
+
+  if ! git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    add_result "$name" "✗" "not a Git worktree"
+    echo "  ✗ $name — not a Git worktree"
+    return 1
+  fi
+
+  if ! dirty_output=$(git -C "$repo" status --porcelain 2>&1); then
+    add_result "$name" "✗" "could not inspect worktree"
+    echo "  ✗ $name — could not inspect worktree"
+    return 1
+  fi
+
+  if [ -n "$dirty_output" ]; then
+    add_result "$name" "⚠" "dirty worktree — skipped"
+    echo "  ⚠ $name — dirty worktree — skipped"
+    return 1
+  fi
+
+  if ! shiv_refresh_package "$name" "$repo"; then
+    add_result "$name" "✗" "failed to refresh generated artifacts"
+    echo "  ✗ $name — failed to refresh generated artifacts"
+    return 1
+  fi
+
+  add_result "$name" "✓" "shim and caches refreshed"
+  echo "  ✓ $name — shim and caches refreshed"
+}
+
+echo "Reshimming $COUNT tool(s)..."
+echo ""
+
+rc=0
+while IFS=$'\t' read -r name repo _ref; do
+  reshim_one "$name" "$repo" || rc=1
+done < <(shiv_registry_entries)
+
+echo ""
+printf '%s\n' "${RESULTS[@]}" \
+  | gum table -s "$SEP" -c "PACKAGE,STATUS,DETAIL" -p --border normal
+
+exit "$rc"

--- a/.mise/tasks/reshim
+++ b/.mise/tasks/reshim
@@ -47,7 +47,7 @@ reshim_one() {
     return 1
   fi
 
-  if ! shiv_refresh_package "$name" "$repo"; then
+  if ! shiv_refresh_package "$name" "$repo" true; then
     add_result "$name" "✗" "failed to refresh generated artifacts"
     echo "  ✗ $name — failed to refresh generated artifacts"
     return 1

--- a/.mise/tasks/reshim
+++ b/.mise/tasks/reshim
@@ -14,6 +14,13 @@ fi
 
 SEP='|'
 RESULTS=()
+ENTRIES_FILE=$(mktemp)
+trap 'rm -f "$ENTRIES_FILE"' EXIT
+
+if ! shiv_registry_entries > "$ENTRIES_FILE"; then
+  echo "Error: could not read registered packages from $SHIV_REGISTRY" >&2
+  exit 1
+fi
 
 add_result() {
   RESULTS+=("$1${SEP}$2${SEP}$3")
@@ -63,7 +70,7 @@ echo ""
 rc=0
 while IFS=$'\t' read -r name repo _ref; do
   reshim_one "$name" "$repo" || rc=1
-done < <(shiv_registry_entries)
+done < "$ENTRIES_FILE"
 
 echo ""
 printf '%s\n' "${RESULTS[@]}" \

--- a/.mise/tasks/update
+++ b/.mise/tasks/update
@@ -36,23 +36,6 @@ package_version() {
   fi
 }
 
-refresh_package() {
-  local name="$1" repo="$2"
-  local aliases=()
-
-  shiv_create_shim "$name" "$repo"
-  shiv_cache_tasks "$name" "$repo"
-  shiv_cache_task_map "$name" "$repo"
-
-  while IFS= read -r _alias; do
-    [ -n "$_alias" ] && aliases+=("$_alias")
-  done < <(shiv_registry_aliases "$name")
-
-  if [ ${#aliases[@]} -gt 0 ]; then
-    shiv_create_alias_symlinks "$name" "${aliases[@]}"
-  fi
-}
-
 update_branch_like() {
   local name="$1" repo="$2" mode="$3" ref="$4"
   local branch before after output version reason count tag
@@ -84,7 +67,7 @@ update_branch_like() {
   if output=$(git -C "$repo" pull --ff-only 2>&1); then
     after=$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo "unknown")
     version=$(package_version "$repo" "$after")
-    refresh_package "$name" "$repo"
+    shiv_refresh_package "$name" "$repo"
 
     if [ "$before" = "$after" ]; then
       add_result "$name" "$branch" "$version" "✓" "already up to date"
@@ -143,7 +126,7 @@ update_release() {
 
   current_tag=$(git -C "$repo" describe --tags --exact-match HEAD 2>/dev/null || echo "")
   if [ "$ref" = "$latest" ] && [ "$current_tag" = "$latest" ]; then
-    refresh_package "$name" "$repo"
+    shiv_refresh_package "$name" "$repo"
     add_result "$name" "$branch" "$version" "✓" "already on latest release"
     echo "  ✓ $name — already on latest release ($latest)"
     return 0
@@ -167,7 +150,7 @@ update_release() {
   branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
   version=$(package_version "$repo" "$after")
   shiv_registry_set_ref "$name" "$latest" "release"
-  refresh_package "$name" "$repo"
+  shiv_refresh_package "$name" "$repo"
 
   if [ "$before" = "$after" ]; then
     add_result "$name" "$branch" "$version" "✓" "release intent recorded as $latest"

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ shimmer --version
 # See what's installed
 shiv list
 
-# Update everything
+# Update package refs, then regenerate every clean registered shim
 shiv update
+shiv reshim
 
 # Check health
 shiv doctor
@@ -107,6 +108,8 @@ shiv install notes@abc1234 # pin an exact commit
 ```
 
 `shiv update` preserves that intent: release-channel installs advance to the newest release tag, branch installs pull their branch, and exact tag/commit pins stay fixed until you reinstall at another ref. Legacy installs without recorded intent are refused with guidance to choose `@latest` or `@main` explicitly.
+
+`shiv reshim` regenerates shims and caches for every clean registered package without moving its Git ref. Dirty, missing, or invalid registered worktrees are reported and make the command fail after safe packages finish; unregistered package directories are never scanned. After upgrading Shiv itself, run `shiv update shiv` followed by `shiv reshim` so every active package uses the new generator.
 
 You can also install directly from a local path:
 

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -16,35 +16,41 @@ shiv_package_tasks_json() {
   )
 }
 
-# Cache task list for a tool (name<TAB>description per line)
-# Writes atomically — only replaces cache if new content is non-empty,
-# so a failed mise invocation doesn't leave an empty cache file.
+# Cache task list for a tool (name<TAB>description per line).
+# Writes atomically and preserves the old cache if task discovery fails.
+# Pass "true" as the third argument when discovery failure must be reported.
 shiv_cache_tasks() {
   [ "${SHIV_SKIP_CACHE:-}" = "1" ] && return 0
 
-  local name="$1" repo_dir="$2"
+  local name="$1" repo_dir="$2" require_refresh="${3:-false}"
   local cache="$SHIV_CACHE_DIR/completions/$name.cache"
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/completions"
   local tasks_json
   if ! tasks_json=$(shiv_package_tasks_json "$repo_dir"); then
     rm -f "$tmp"
+    if [ "$require_refresh" = "true" ]; then
+      return 1
+    fi
     return 0
   fi
   if [ -z "$tasks_json" ]; then
-    rm -f "$tmp"
+    rm -f "$tmp" "$cache"
     return 0
   fi
   if ! printf '%s\n' "$tasks_json" \
     | jq -r '.[] | select(.global != true) | select(.hide == false) | "\(.name)\t\(.description)"' \
     > "$tmp"; then
     rm -f "$tmp"
+    if [ "$require_refresh" = "true" ]; then
+      return 1
+    fi
     return 0
   fi
   if [ -s "$tmp" ]; then
     mv "$tmp" "$cache"
   else
-    rm -f "$tmp"
+    rm -f "$tmp" "$cache"
   fi
 }
 
@@ -60,30 +66,36 @@ shiv_cache_tasks() {
 shiv_cache_task_map() {
   [ "${SHIV_SKIP_CACHE:-}" = "1" ] && return 0
 
-  local name="$1" repo_dir="$2"
+  local name="$1" repo_dir="$2" require_refresh="${3:-false}"
   local cache="$SHIV_CACHE_DIR/tasks/$name"
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/tasks"
   local tasks_json
   if ! tasks_json=$(shiv_package_tasks_json "$repo_dir" --hidden); then
     rm -f "$tmp"
+    if [ "$require_refresh" = "true" ]; then
+      return 1
+    fi
     return 0
   fi
   if [ -z "$tasks_json" ]; then
-    rm -f "$tmp"
+    rm -f "$tmp" "$cache"
     return 0
   fi
   if ! printf '%s\n' "$tasks_json" \
     | jq -r '.[] | select(.global != true) | .name | gsub(":"; " ")' \
     > "$tmp"; then
     rm -f "$tmp"
+    if [ "$require_refresh" = "true" ]; then
+      return 1
+    fi
     return 0
   fi
 
   if [ -s "$tmp" ]; then
     mv "$tmp" "$cache"
   else
-    rm -f "$tmp"
+    rm -f "$tmp" "$cache"
   fi
 }
 

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -364,13 +364,13 @@ shiv_create_alias_symlinks() {
 
 # Refresh every generated artifact for a registered package.
 shiv_refresh_package() {
-  local name="$1" repo_dir="$2"
+  local name="$1" repo_dir="$2" require_cache_refresh="${3:-false}"
   local aliases=()
   local alias_output
 
   shiv_create_shim "$name" "$repo_dir" || return 1
-  shiv_cache_tasks "$name" "$repo_dir" || return 1
-  shiv_cache_task_map "$name" "$repo_dir" || return 1
+  shiv_cache_tasks "$name" "$repo_dir" "$require_cache_refresh" || return 1
+  shiv_cache_task_map "$name" "$repo_dir" "$require_cache_refresh" || return 1
 
   alias_output=$(shiv_registry_aliases "$name") || return 1
   while IFS= read -r alias; do

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -358,8 +358,28 @@ shiv_create_alias_symlinks() {
   shift
   local aliases=("$@")
   for alias in "${aliases[@]}"; do
-    ln -sf "$name" "$SHIV_BIN_DIR/$alias"
+    ln -sf "$name" "$SHIV_BIN_DIR/$alias" || return 1
   done
+}
+
+# Refresh every generated artifact for a registered package.
+shiv_refresh_package() {
+  local name="$1" repo_dir="$2"
+  local aliases=()
+  local alias_output
+
+  shiv_create_shim "$name" "$repo_dir" || return 1
+  shiv_cache_tasks "$name" "$repo_dir" || return 1
+  shiv_cache_task_map "$name" "$repo_dir" || return 1
+
+  alias_output=$(shiv_registry_aliases "$name") || return 1
+  while IFS= read -r alias; do
+    [ -n "$alias" ] && aliases+=("$alias")
+  done <<< "$alias_output"
+
+  if [ "${#aliases[@]}" -gt 0 ]; then
+    shiv_create_alias_symlinks "$name" "${aliases[@]}" || return 1
+  fi
 }
 
 # Quote a value for POSIX-ish shell eval output.

--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -100,6 +100,17 @@ run_reshim() {
   create_package_repo dirty-tool
   register_package dirty-tool local main dirty-alias
 
+  mkdir -p "$SHIV_PACKAGES_DIR/dirty-tool/.mise/tasks"
+  cat > "$SHIV_PACKAGES_DIR/dirty-tool/.mise/tasks/current" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Current task"
+echo current
+TASK
+  chmod +x "$SHIV_PACKAGES_DIR/dirty-tool/.mise/tasks/current"
+  git -C "$SHIV_PACKAGES_DIR/dirty-tool" add .mise/tasks/current
+  git -C "$SHIV_PACKAGES_DIR/dirty-tool" commit -q -m "add task"
+  unset SHIV_SKIP_CACHE
+
   printf 'old shim\n' > "$SHIV_BIN_DIR/dirty-tool"
   ln -s old-target "$SHIV_BIN_DIR/dirty-alias"
   mkdir -p "$SHIV_CACHE_DIR/completions" "$SHIV_CACHE_DIR/tasks"

--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -117,6 +117,31 @@ run_reshim() {
   [ "$(cat "$SHIV_CACHE_DIR/tasks/dirty-tool")" = "old task map" ]
 }
 
+@test "reshim: caller Git environment cannot bypass the dirty-worktree guard" {
+  create_package_repo dirty-tool
+  register_package dirty-tool local main
+  printf 'old shim\n' > "$SHIV_BIN_DIR/dirty-tool"
+  printf 'dirty\n' >> "$SHIV_PACKAGES_DIR/dirty-tool/README.md"
+
+  local caller_repo="$BATS_TEST_TMPDIR/caller-repo"
+  mkdir -p "$caller_repo"
+  git -C "$caller_repo" init -q -b main
+  git -C "$caller_repo" config user.email "test@test.com"
+  git -C "$caller_repo" config user.name "Test"
+  printf 'clean\n' > "$caller_repo/README.md"
+  git -C "$caller_repo" add README.md
+  git -C "$caller_repo" commit -q -m "init"
+
+  export GIT_DIR="$caller_repo/.git"
+  export GIT_WORK_TREE="$caller_repo"
+  run run_reshim
+  unset GIT_DIR GIT_WORK_TREE
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"dirty-tool — dirty worktree — skipped"* ]]
+  [ "$(cat "$SHIV_BIN_DIR/dirty-tool")" = "old shim" ]
+}
+
 @test "reshim: missing and invalid repos fail while clean registered packages continue" {
   create_package_repo clean-tool
   register_package clean-tool branch main

--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -117,6 +117,26 @@ run_reshim() {
   [ "$(cat "$SHIV_CACHE_DIR/tasks/dirty-tool")" = "old task map" ]
 }
 
+@test "reshim: cache discovery failure is reported and preserves old caches" {
+  create_package_repo broken-cache
+  register_package broken-cache branch main
+
+  mkdir -p "$SHIV_CACHE_DIR/completions" "$SHIV_CACHE_DIR/tasks"
+  printf 'old completions\n' > "$SHIV_CACHE_DIR/completions/broken-cache.cache"
+  printf 'old task map\n' > "$SHIV_CACHE_DIR/tasks/broken-cache"
+  printf '[invalid\n' > "$SHIV_PACKAGES_DIR/broken-cache/mise.toml"
+  git -C "$SHIV_PACKAGES_DIR/broken-cache" add mise.toml
+  git -C "$SHIV_PACKAGES_DIR/broken-cache" commit -q -m "add invalid mise config"
+  unset SHIV_SKIP_CACHE
+
+  run run_reshim
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"broken-cache — failed to refresh generated artifacts"* ]]
+  [ "$(cat "$SHIV_CACHE_DIR/completions/broken-cache.cache")" = "old completions" ]
+  [ "$(cat "$SHIV_CACHE_DIR/tasks/broken-cache")" = "old task map" ]
+}
+
 @test "reshim: missing and invalid repos fail while clean registered packages continue" {
   create_package_repo clean-tool
   register_package clean-tool branch main
@@ -157,4 +177,14 @@ TASK
   [ "$status" -eq 0 ]
   grep -q $'^hello\tSay hello$' "$SHIV_CACHE_DIR/completions/cached-tool.cache"
   grep -q '^hello$' "$SHIV_CACHE_DIR/tasks/cached-tool"
+
+  rm "$SHIV_PACKAGES_DIR/cached-tool/.mise/tasks/hello"
+  git -C "$SHIV_PACKAGES_DIR/cached-tool" add -u
+  git -C "$SHIV_PACKAGES_DIR/cached-tool" commit -q -m "remove task"
+
+  run run_reshim
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$SHIV_CACHE_DIR/completions/cached-tool.cache" ]
+  [ ! -e "$SHIV_CACHE_DIR/tasks/cached-tool" ]
 }

--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -53,6 +53,16 @@ run_reshim() {
   [[ "$output" == *"No tools registered."* ]]
 }
 
+@test "reshim: invalid registry entries fail instead of disappearing" {
+  printf '%s\n' '{"broken":"not-an-object"}' > "$SHIV_REGISTRY"
+
+  run run_reshim
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not read registered packages"* ]]
+  [ ! -e "$SHIV_BIN_DIR/broken" ]
+}
+
 @test "reshim: refreshes exact, local, self, and alias artifacts without scanning package storage" {
   create_package_repo shiv
   git -C "$SHIV_PACKAGES_DIR/shiv" -c tag.gpgSign=false tag v1.0.0

--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# shiv reshim test suite
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+load helpers
+
+setup() {
+  source "$REPO_DIR/lib/shim.sh"
+
+  export TEST_HOME="$BATS_TEST_TMPDIR/shiv"
+  export SHIV_BIN_DIR="$TEST_HOME/.local/bin"
+  export SHIV_DATA_DIR="$TEST_HOME/.local/share/shiv"
+  export SHIV_PACKAGES_DIR="$SHIV_DATA_DIR/packages"
+  export SHIV_CONFIG_DIR="$TEST_HOME/.config/shiv"
+  export SHIV_CACHE_DIR="$TEST_HOME/.cache/shiv"
+  export SHIV_REGISTRY="$SHIV_CONFIG_DIR/registry.json"
+  export SHIV_SKIP_CACHE=1
+
+  mkdir -p "$SHIV_BIN_DIR"
+  shiv_init_registry
+  setup_shiv_on_path
+}
+
+create_package_repo() {
+  local name="$1"
+  local repo="$SHIV_PACKAGES_DIR/$name"
+
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email "test@test.com"
+  git -C "$repo" config user.name "Test"
+  printf '# %s\n' "$name" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+}
+
+register_package() {
+  local name="$1" mode="$2" ref="$3"
+  shift 3
+  local repo="$SHIV_PACKAGES_DIR/$name"
+
+  SHIV_REF="$ref" SHIV_REF_MODE="$mode" shiv_register "$name" "$repo" "$@"
+}
+
+run_reshim() {
+  shiv reshim
+}
+
+@test "reshim: empty registry shows message" {
+  run run_reshim
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No tools registered."* ]]
+}
+
+@test "reshim: refreshes exact, local, self, and alias artifacts without scanning package storage" {
+  create_package_repo shiv
+  git -C "$SHIV_PACKAGES_DIR/shiv" -c tag.gpgSign=false tag v1.0.0
+  register_package shiv tag v1.0.0 shiv-next
+
+  create_package_repo local-tool
+  register_package local-tool local main
+
+  local shiv_head local_head shiv_branch local_branch
+  shiv_head=$(git -C "$SHIV_PACKAGES_DIR/shiv" rev-parse HEAD)
+  local_head=$(git -C "$SHIV_PACKAGES_DIR/local-tool" rev-parse HEAD)
+  shiv_branch=$(git -C "$SHIV_PACKAGES_DIR/shiv" branch --show-current)
+  local_branch=$(git -C "$SHIV_PACKAGES_DIR/local-tool" branch --show-current)
+
+  printf 'stale shiv\n' > "$SHIV_BIN_DIR/shiv"
+  printf 'stale local\n' > "$SHIV_BIN_DIR/local-tool"
+
+  mkdir -p "$SHIV_PACKAGES_DIR/inactive"
+  printf 'do not touch\n' > "$SHIV_PACKAGES_DIR/inactive/sentinel"
+  printf 'inactive shim\n' > "$SHIV_BIN_DIR/inactive"
+
+  run run_reshim
+
+  [ "$status" -eq 0 ]
+  local reshim_output="$output"
+  [ "$(git -C "$SHIV_PACKAGES_DIR/shiv" rev-parse HEAD)" = "$shiv_head" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/local-tool" rev-parse HEAD)" = "$local_head" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/shiv" branch --show-current)" = "$shiv_branch" ]
+  [ "$(git -C "$SHIV_PACKAGES_DIR/local-tool" branch --show-current)" = "$local_branch" ]
+  grep -q '^# managed by shiv$' "$SHIV_BIN_DIR/shiv"
+  grep -q '^# managed by shiv$' "$SHIV_BIN_DIR/local-tool"
+  [ "$(readlink "$SHIV_BIN_DIR/shiv-next")" = "shiv" ]
+  [ "$(cat "$SHIV_PACKAGES_DIR/inactive/sentinel")" = "do not touch" ]
+  [ "$(cat "$SHIV_BIN_DIR/inactive")" = "inactive shim" ]
+  [[ "$reshim_output" == *"✓ shiv — shim and caches refreshed"* ]]
+  [[ "$reshim_output" == *"✓ local-tool — shim and caches refreshed"* ]]
+  [[ "$reshim_output" != *"inactive"* ]]
+
+  run "$SHIV_BIN_DIR/shiv" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"shiv v1.0.0 (branch:"* ]]
+}
+
+@test "reshim: dirty package fails visibly before changing any generated artifact" {
+  create_package_repo dirty-tool
+  register_package dirty-tool local main dirty-alias
+
+  printf 'old shim\n' > "$SHIV_BIN_DIR/dirty-tool"
+  ln -s old-target "$SHIV_BIN_DIR/dirty-alias"
+  mkdir -p "$SHIV_CACHE_DIR/completions" "$SHIV_CACHE_DIR/tasks"
+  printf 'old completions\n' > "$SHIV_CACHE_DIR/completions/dirty-tool.cache"
+  printf 'old task map\n' > "$SHIV_CACHE_DIR/tasks/dirty-tool"
+  printf 'dirty\n' >> "$SHIV_PACKAGES_DIR/dirty-tool/README.md"
+
+  run run_reshim
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"dirty-tool — dirty worktree — skipped"* ]]
+  [ "$(cat "$SHIV_BIN_DIR/dirty-tool")" = "old shim" ]
+  [ "$(readlink "$SHIV_BIN_DIR/dirty-alias")" = "old-target" ]
+  [ "$(cat "$SHIV_CACHE_DIR/completions/dirty-tool.cache")" = "old completions" ]
+  [ "$(cat "$SHIV_CACHE_DIR/tasks/dirty-tool")" = "old task map" ]
+}
+
+@test "reshim: missing and invalid repos fail while clean registered packages continue" {
+  create_package_repo clean-tool
+  register_package clean-tool branch main
+  SHIV_REF=main SHIV_REF_MODE=branch \
+    shiv_register missing-tool "$SHIV_PACKAGES_DIR/missing-tool"
+  mkdir -p "$SHIV_PACKAGES_DIR/not-git"
+  SHIV_REF=main SHIV_REF_MODE=local \
+    shiv_register invalid-tool "$SHIV_PACKAGES_DIR/not-git"
+
+  printf 'stale clean\n' > "$SHIV_BIN_DIR/clean-tool"
+
+  run run_reshim
+
+  [ "$status" -eq 1 ]
+  grep -q '^# managed by shiv$' "$SHIV_BIN_DIR/clean-tool"
+  [[ "$output" == *"✓ clean-tool — shim and caches refreshed"* ]]
+  [[ "$output" == *"✗ missing-tool — repo not found"* ]]
+  [[ "$output" == *"✗ invalid-tool — not a Git worktree"* ]]
+}
+
+@test "reshim: refreshes completion and task-map caches through the public command" {
+  create_package_repo cached-tool
+  register_package cached-tool branch main
+  unset SHIV_SKIP_CACHE
+
+  mkdir -p "$SHIV_PACKAGES_DIR/cached-tool/.mise/tasks"
+  cat > "$SHIV_PACKAGES_DIR/cached-tool/.mise/tasks/hello" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Say hello"
+echo hello
+TASK
+  chmod +x "$SHIV_PACKAGES_DIR/cached-tool/.mise/tasks/hello"
+  git -C "$SHIV_PACKAGES_DIR/cached-tool" add .mise/tasks/hello
+  git -C "$SHIV_PACKAGES_DIR/cached-tool" commit -q -m "add task"
+
+  run run_reshim
+
+  [ "$status" -eq 0 ]
+  grep -q $'^hello\tSay hello$' "$SHIV_CACHE_DIR/completions/cached-tool.cache"
+  grep -q '^hello$' "$SHIV_CACHE_DIR/tasks/cached-tool"
+}


### PR DESCRIPTION
## Summary

- add `shiv reshim` to regenerate artifacts for every clean registered package
- centralize shim, cache, task-map, and alias refresh behavior for update and reshim
- preserve package refs, skip dirty worktrees before writes, and ignore unregistered package directories
- document the self-upgrade workflow: `shiv update shiv`, then `shiv reshim`

## Validation

- `codebase lint`
- `mise run test reshim`
- `mise run test update`
- `mise run test` (296 tests)
