### PR TITLE
fix: propagate reshim registry read failures

### DIFF
--- a/.mise/tasks/reshim
+++ b/.mise/tasks/reshim
@@ -14,6 +14,13 @@ fi
 
 SEP='|'
 RESULTS=()
+ENTRIES_FILE=$(mktemp)
+trap 'rm -f "$ENTRIES_FILE"' EXIT
+
+if ! shiv_registry_entries > "$ENTRIES_FILE"; then
+  echo "Error: could not read registered packages from $SHIV_REGISTRY" >&2
+  exit 1
+fi
 
 add_result() {
   RESULTS+=("$1${SEP}$2${SEP}$3")
@@ -63,7 +70,7 @@ echo ""
 rc=0
 while IFS=$'\t' read -r name repo _ref; do
   reshim_one "$name" "$repo" || rc=1
-done < <(shiv_registry_entries)
+done < "$ENTRIES_FILE"
 
 echo ""
 printf '%s\n' "${RESULTS[@]}" \

--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -53,6 +53,16 @@ run_reshim() {
   [[ "$output" == *"No tools registered."* ]]
 }
 
+@test "reshim: invalid registry entries fail instead of disappearing" {
+  printf '%s\n' '{"broken":"not-an-object"}' > "$SHIV_REGISTRY"
+
+  run run_reshim
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not read registered packages"* ]]
+  [ ! -e "$SHIV_BIN_DIR/broken" ]
+}
+
 @test "reshim: refreshes exact, local, self, and alias artifacts without scanning package storage" {
   create_package_repo shiv
   git -C "$SHIV_PACKAGES_DIR/shiv" -c tag.gpgSign=false tag v1.0.0


### PR DESCRIPTION
## Summary

- materialize registry entries before refreshing packages
- fail when `shiv_registry_entries` cannot decode a registered entry
- cover malformed registry data through the public `shiv reshim` test path

## Why

PR #153 consumes `shiv_registry_entries` through process substitution. Bash does not propagate a process-substitution failure to the loop, so a malformed entry prints a jq error but `shiv reshim` exits 0 after processing no packages.

## Validation

- `mise run test reshim`
- `mise exec shiv:codebase -- codebase lint`

Fix-it for KnickKnackLabs/shiv#153.
