### PR TITLE
fix: make reshim cache results accurate

### DIFF
--- a/.mise/tasks/reshim
+++ b/.mise/tasks/reshim
@@ -47,7 +47,7 @@ reshim_one() {
     return 1
   fi
 
-  if ! shiv_refresh_package "$name" "$repo"; then
+  if ! shiv_refresh_package "$name" "$repo" true; then
     add_result "$name" "✗" "failed to refresh generated artifacts"
     echo "  ✗ $name — failed to refresh generated artifacts"
     return 1

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -16,35 +16,41 @@ shiv_package_tasks_json() {
   )
 }
 
-# Cache task list for a tool (name<TAB>description per line)
-# Writes atomically — only replaces cache if new content is non-empty,
-# so a failed mise invocation doesn't leave an empty cache file.
+# Cache task list for a tool (name<TAB>description per line).
+# Writes atomically and preserves the old cache if task discovery fails.
+# Pass "true" as the third argument when discovery failure must be reported.
 shiv_cache_tasks() {
   [ "${SHIV_SKIP_CACHE:-}" = "1" ] && return 0
 
-  local name="$1" repo_dir="$2"
+  local name="$1" repo_dir="$2" require_refresh="${3:-false}"
   local cache="$SHIV_CACHE_DIR/completions/$name.cache"
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/completions"
   local tasks_json
   if ! tasks_json=$(shiv_package_tasks_json "$repo_dir"); then
     rm -f "$tmp"
+    if [ "$require_refresh" = "true" ]; then
+      return 1
+    fi
     return 0
   fi
   if [ -z "$tasks_json" ]; then
-    rm -f "$tmp"
+    rm -f "$tmp" "$cache"
     return 0
   fi
   if ! printf '%s\n' "$tasks_json" \
     | jq -r '.[] | select(.global != true) | select(.hide == false) | "\(.name)\t\(.description)"' \
     > "$tmp"; then
     rm -f "$tmp"
+    if [ "$require_refresh" = "true" ]; then
+      return 1
+    fi
     return 0
   fi
   if [ -s "$tmp" ]; then
     mv "$tmp" "$cache"
   else
-    rm -f "$tmp"
+    rm -f "$tmp" "$cache"
   fi
 }
 
@@ -60,30 +66,36 @@ shiv_cache_tasks() {
 shiv_cache_task_map() {
   [ "${SHIV_SKIP_CACHE:-}" = "1" ] && return 0
 
-  local name="$1" repo_dir="$2"
+  local name="$1" repo_dir="$2" require_refresh="${3:-false}"
   local cache="$SHIV_CACHE_DIR/tasks/$name"
   local tmp="$cache.tmp"
   mkdir -p "$SHIV_CACHE_DIR/tasks"
   local tasks_json
   if ! tasks_json=$(shiv_package_tasks_json "$repo_dir" --hidden); then
     rm -f "$tmp"
+    if [ "$require_refresh" = "true" ]; then
+      return 1
+    fi
     return 0
   fi
   if [ -z "$tasks_json" ]; then
-    rm -f "$tmp"
+    rm -f "$tmp" "$cache"
     return 0
   fi
   if ! printf '%s\n' "$tasks_json" \
     | jq -r '.[] | select(.global != true) | .name | gsub(":"; " ")' \
     > "$tmp"; then
     rm -f "$tmp"
+    if [ "$require_refresh" = "true" ]; then
+      return 1
+    fi
     return 0
   fi
 
   if [ -s "$tmp" ]; then
     mv "$tmp" "$cache"
   else
-    rm -f "$tmp"
+    rm -f "$tmp" "$cache"
   fi
 }
 

--- a/lib/shim.sh
+++ b/lib/shim.sh
@@ -364,13 +364,13 @@ shiv_create_alias_symlinks() {
 
 # Refresh every generated artifact for a registered package.
 shiv_refresh_package() {
-  local name="$1" repo_dir="$2"
+  local name="$1" repo_dir="$2" require_cache_refresh="${3:-false}"
   local aliases=()
   local alias_output
 
   shiv_create_shim "$name" "$repo_dir" || return 1
-  shiv_cache_tasks "$name" "$repo_dir" || return 1
-  shiv_cache_task_map "$name" "$repo_dir" || return 1
+  shiv_cache_tasks "$name" "$repo_dir" "$require_cache_refresh" || return 1
+  shiv_cache_task_map "$name" "$repo_dir" "$require_cache_refresh" || return 1
 
   alias_output=$(shiv_registry_aliases "$name") || return 1
   while IFS= read -r alias; do

--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -117,6 +117,26 @@ run_reshim() {
   [ "$(cat "$SHIV_CACHE_DIR/tasks/dirty-tool")" = "old task map" ]
 }
 
+@test "reshim: cache discovery failure is reported and preserves old caches" {
+  create_package_repo broken-cache
+  register_package broken-cache branch main
+
+  mkdir -p "$SHIV_CACHE_DIR/completions" "$SHIV_CACHE_DIR/tasks"
+  printf 'old completions\n' > "$SHIV_CACHE_DIR/completions/broken-cache.cache"
+  printf 'old task map\n' > "$SHIV_CACHE_DIR/tasks/broken-cache"
+  printf '[invalid\n' > "$SHIV_PACKAGES_DIR/broken-cache/mise.toml"
+  git -C "$SHIV_PACKAGES_DIR/broken-cache" add mise.toml
+  git -C "$SHIV_PACKAGES_DIR/broken-cache" commit -q -m "add invalid mise config"
+  unset SHIV_SKIP_CACHE
+
+  run run_reshim
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"broken-cache — failed to refresh generated artifacts"* ]]
+  [ "$(cat "$SHIV_CACHE_DIR/completions/broken-cache.cache")" = "old completions" ]
+  [ "$(cat "$SHIV_CACHE_DIR/tasks/broken-cache")" = "old task map" ]
+}
+
 @test "reshim: missing and invalid repos fail while clean registered packages continue" {
   create_package_repo clean-tool
   register_package clean-tool branch main
@@ -157,4 +177,14 @@ TASK
   [ "$status" -eq 0 ]
   grep -q $'^hello\tSay hello$' "$SHIV_CACHE_DIR/completions/cached-tool.cache"
   grep -q '^hello$' "$SHIV_CACHE_DIR/tasks/cached-tool"
+
+  rm "$SHIV_PACKAGES_DIR/cached-tool/.mise/tasks/hello"
+  git -C "$SHIV_PACKAGES_DIR/cached-tool" add -u
+  git -C "$SHIV_PACKAGES_DIR/cached-tool" commit -q -m "remove task"
+
+  run run_reshim
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$SHIV_CACHE_DIR/completions/cached-tool.cache" ]
+  [ ! -e "$SHIV_CACHE_DIR/tasks/cached-tool" ]
 }


### PR DESCRIPTION
## Summary

- let callers require cache-discovery failures to propagate
- make `reshim` use that strict result while preserving update/install best-effort behavior
- remove stale completion and task-map caches when successful discovery finds no package tasks
- test both discovery failure and task removal through `shiv reshim`

## Why

PR #153 reports “shim and caches refreshed” even when `mise tasks` fails and no cache is generated. It also leaves old non-empty caches behind when a package validly removes all tasks. Both cases return success with artifacts that do not represent the registered package.

## Validation

- `mise run test reshim`
- `mise run test resolve completions update` (82 tests; zsh/fish syntax checks skipped because those shells are not installed)
- `mise exec shiv:codebase -- codebase lint`

Fix-it for KnickKnackLabs/shiv#153.
