### PR TITLE
fix: isolate reshim from caller Git environment

### DIFF
--- a/.mise/tasks/reshim
+++ b/.mise/tasks/reshim
@@ -4,6 +4,13 @@ set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/shim.sh"
 
+# Git exports repository-selection variables to hooks. Clear them before
+# inspecting registered packages so caller metadata cannot override git -C.
+git_local_env_vars=$(git rev-parse --local-env-vars 2>/dev/null)
+while IFS= read -r git_var; do
+  [ -n "$git_var" ] && unset "$git_var"
+done <<< "$git_local_env_vars"
+
 shiv_init_registry
 
 COUNT=$(jq 'length' "$SHIV_REGISTRY")

--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -117,6 +117,31 @@ run_reshim() {
   [ "$(cat "$SHIV_CACHE_DIR/tasks/dirty-tool")" = "old task map" ]
 }
 
+@test "reshim: caller Git environment cannot bypass the dirty-worktree guard" {
+  create_package_repo dirty-tool
+  register_package dirty-tool local main
+  printf 'old shim\n' > "$SHIV_BIN_DIR/dirty-tool"
+  printf 'dirty\n' >> "$SHIV_PACKAGES_DIR/dirty-tool/README.md"
+
+  local caller_repo="$BATS_TEST_TMPDIR/caller-repo"
+  mkdir -p "$caller_repo"
+  git -C "$caller_repo" init -q -b main
+  git -C "$caller_repo" config user.email "test@test.com"
+  git -C "$caller_repo" config user.name "Test"
+  printf 'clean\n' > "$caller_repo/README.md"
+  git -C "$caller_repo" add README.md
+  git -C "$caller_repo" commit -q -m "init"
+
+  export GIT_DIR="$caller_repo/.git"
+  export GIT_WORK_TREE="$caller_repo"
+  run run_reshim
+  unset GIT_DIR GIT_WORK_TREE
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"dirty-tool — dirty worktree — skipped"* ]]
+  [ "$(cat "$SHIV_BIN_DIR/dirty-tool")" = "old shim" ]
+}
+
 @test "reshim: missing and invalid repos fail while clean registered packages continue" {
   create_package_repo clean-tool
   register_package clean-tool branch main


### PR DESCRIPTION
## Summary

- clear Git’s repository-selection environment before inspecting registered packages
- prove that inherited `GIT_DIR` and `GIT_WORK_TREE` cannot redirect the dirty-worktree check

## Why

PR #153 uses `git -C "$repo"` as the safety gate before generated writes. Git’s exported repository-selection variables take precedence over `-C`, so invoking `shiv reshim` from a Git hook can inspect a different clean repository, regenerate a dirty package’s shim, and report success.

## Validation

- `mise run test reshim`
- real `mise run reshim` fixture with a dirty package plus clean caller `GIT_DIR`/`GIT_WORK_TREE`
- `mise exec shiv:codebase -- codebase lint`

Fix-it for KnickKnackLabs/shiv#153.
