### PR TITLE
test: exercise dirty-package cache guard

### DIFF
--- a/test/reshim.bats
+++ b/test/reshim.bats
@@ -100,6 +100,17 @@ run_reshim() {
   create_package_repo dirty-tool
   register_package dirty-tool local main dirty-alias
 
+  mkdir -p "$SHIV_PACKAGES_DIR/dirty-tool/.mise/tasks"
+  cat > "$SHIV_PACKAGES_DIR/dirty-tool/.mise/tasks/current" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Current task"
+echo current
+TASK
+  chmod +x "$SHIV_PACKAGES_DIR/dirty-tool/.mise/tasks/current"
+  git -C "$SHIV_PACKAGES_DIR/dirty-tool" add .mise/tasks/current
+  git -C "$SHIV_PACKAGES_DIR/dirty-tool" commit -q -m "add task"
+  unset SHIV_SKIP_CACHE
+
   printf 'old shim\n' > "$SHIV_BIN_DIR/dirty-tool"
   ln -s old-target "$SHIV_BIN_DIR/dirty-alias"
   mkdir -p "$SHIV_CACHE_DIR/completions" "$SHIV_CACHE_DIR/tasks"


### PR DESCRIPTION
## Summary

- run cache generation in the dirty-package safety test
- give the package a real task so an accidental pre-guard cache refresh would change both caches

## Why

PR #153’s dirty-package test sets `SHIV_SKIP_CACHE=1` in setup. Its old-cache assertions therefore pass even if cache generation happens before the dirty-worktree check. The shim and alias assertions still test part of the guard, but the test claims protection for every generated artifact.

## Validation

- `mise run test reshim`
- `mise exec shiv:codebase -- codebase lint`

Fix-it for KnickKnackLabs/shiv#153.
